### PR TITLE
Revert to original device-common.mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
-/src/LPC4330_M4/
+# Build output
+*.bin
+*.disasm
+*.elf
+*.hex
+*.map
+*.o
+*.d
+*.a
+
+# Editor temporary files
 *~
+
+# OS specific files
 .DS_Store

--- a/gcc4mbed/build/device-common.mk
+++ b/gcc4mbed/build/device-common.mk
@@ -87,7 +87,6 @@ OBJECTS := $(filter-out $(EXCL_OBJECTS),$(OBJECTS))
 
 # Add in the GCC4MBED stubs which allow hooking in the MRI debug monitor.
 OBJECTS += $(OUTDIR)/gcc4mbed.o
-OBJECTS += $(OUTDIR)/configdefault.o
 
 # Add in device specific object file(s).
 OBJECTS += $(DEVICE_OBJECTS)
@@ -213,9 +212,6 @@ $(OUTDIR)/%.o : $(SRC)/%.s makefile
 	$(Q) $(MKDIR) $(call convert-slash,$(dir $@)) $(QUIET)
 	$(Q) $(GCC) $(ASM_FLAGS) $(MBED_INCLUDES) -c $< -o $@
 
-$(OUTDIR)/configdefault.o : $(SRC)/config.default
-	@echo Packing $<
-	$(Q) $(OBJCOPY) -I binary -O elf32-littlearm -B arm --readonly-text --rename-section .data=.rodata.configdefault $< $@
 
 ###############################################################################
 # Library mbed.a

--- a/src/makefile
+++ b/src/makefile
@@ -17,8 +17,13 @@ GCC4MBED_DIR       := ../gcc4mbed/
 NO_FLOAT_SCANF     := 1
 NO_FLOAT_PRINTF    := 0
 LPC4330_M4_LSCRIPT := LPC4337.ld
+LIBS_PREFIX        := configdefault.o
 
 include $(GCC4MBED_DIR)/build/gcc4mbed.mk
+
+configdefault.o : config.default
+	@echo Packing $<
+	$(Q) $(OBJCOPY) -I binary -O elf32-littlearm -B arm --readonly-text --rename-section .data=.rodata.configdefault $< $@
 
 flash:
 	lpc21isp LPC4330_M4/Smoothie2.hex /dev/ttyUSB0 115200 14746


### PR DESCRIPTION
Reverts the gcc4mbed makefiles back to what is in the main gcc4mbed github repo.  This moves the configdefault.o specific build steps from the general gcc4mbed makefiles to the Smoothie specific
makefile.

gcc4mbed/samples will now build successfully with this fix.  I also verified that exactly the same Smoothie .bin image is built before and after applying this fix.
