### PR TITLE
Use C++11 features for the checksums

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -19,6 +19,9 @@ NO_FLOAT_PRINTF    := 0
 LPC4330_M4_LSCRIPT := LPC4337.ld
 LIBS_PREFIX        := configdefault.o
 
+# Use C++11 features for the checksums
+DEFINES += -DCHECKSUM_USE_CPP
+
 include $(GCC4MBED_DIR)/build/gcc4mbed.mk
 
 configdefault.o : config.default


### PR DESCRIPTION
Without this unoptimized builds are too large since the compiler
disables the necessary constant folding for the macro approach.
