### PR TITLE
Add Bambino support to makefile

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -59,10 +59,14 @@ Kernel::Kernel(){
     this->streams = new StreamOutputPool();
 
     // Create the default UART Serial Console interface
-    this->serial = new SerialConsole(P6_5, P6_4, 9600);
-    this->add_module( this->serial );
-    this->secondary_serial = new SerialConsole(P1_14, P5_6, 9600);
-    this->add_module( this->secondary_serial );
+    if (SMOOTHIE_UART_PRIMARY_ENABLE) {
+        this->serial = new SerialConsole(SMOOTHIE_UART_PRIMARY_TX, SMOOTHIE_UART_PRIMARY_RX, 9600);
+        this->add_module( this->serial );
+    }
+    if (SMOOTHIE_UART_SECONDARY_ENABLE) {
+        this->secondary_serial = new SerialConsole(SMOOTHIE_UART_SECONDARY_TX, SMOOTHIE_UART_SECONDARY_RX, 9600);
+        this->add_module( this->secondary_serial );
+    }
 
     // Config next, but does not load cache yet
     this->config = new Config();

--- a/src/makefile
+++ b/src/makefile
@@ -1,29 +1,57 @@
-# Copyright 2015 Adam Green (http://mbed.org/users/AdamGreen/)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 PROJECT            := Smoothie2
 DEVICES            := LPC4330_M4
 GCC4MBED_DIR       := ../gcc4mbed/
 NO_FLOAT_SCANF     := 1
 NO_FLOAT_PRINTF    := 0
-LPC4330_M4_LSCRIPT := LPC4337.ld
 LIBS_PREFIX        := configdefault.o
 OPTIMIZATION       =  0
 
 # Use C++11 features for the checksums
 DEFINES += -DCHECKSUM_USE_CPP
 
+
+# Select the board that you want to build Smoothie to run upon.
+# Can be one of: Smoothie2 (**default**)
+#                Bambino210E
+#                Bambino200E
+BOARD ?= Smoothie2
+
+# Need to use a custom LPC4337 script for boards like the Smoothie2 hardware which use that chip instead of the LPC4330.
+ifeq "$(BOARD)" "Smoothie2"
+LPC4330_M4_LSCRIPT := LPC4337.ld
+endif
+
+# Select the UART to be used for primary and secondary console (if any).
+ifeq "$(BOARD)" "Smoothie2"
+DEFINES += -DSMOOTHIE_UART_PRIMARY_ENABLE=1
+DEFINES += -DSMOOTHIE_UART_PRIMARY_TX=P3_4
+DEFINES += -DSMOOTHIE_UART_PRIMARY_RX=P3_5
+DEFINES += -DSMOOTHIE_UART_SECONDARY_ENABLE=1
+DEFINES += -DSMOOTHIE_UART_SECONDARY_TX=P2_0
+DEFINES += -DSMOOTHIE_UART_SECONDARY_RX=P2_1
+endif
+
+ifeq "$(BOARD)" "Bambino210E"
+DEFINES += -DSMOOTHIE_UART_PRIMARY_ENABLE=1
+DEFINES += -DSMOOTHIE_UART_PRIMARY_TX=P2_10
+DEFINES += -DSMOOTHIE_UART_PRIMARY_RX=P2_11
+DEFINES += -DSMOOTHIE_UART_SECONDARY_ENABLE=1
+DEFINES += -DSMOOTHIE_UART_SECONDARY_TX=P6_4
+DEFINES += -DSMOOTHIE_UART_SECONDARY_RX=P6_5
+endif
+
+ifeq "$(BOARD)" "Bambino200E"
+DEFINES += -DSMOOTHIE_UART_PRIMARY_ENABLE=1
+DEFINES += -DSMOOTHIE_UART_PRIMARY_TX=P6_4
+DEFINES += -DSMOOTHIE_UART_PRIMARY_RX=P6_5
+DEFINES += -DSMOOTHIE_UART_SECONDARY_ENABLE=1
+DEFINES += -DSMOOTHIE_UART_SECONDARY_TX=P5_6
+DEFINES += -DSMOOTHIE_UART_SECONDARY_RX=P1_14
+endif
+
+
 include $(GCC4MBED_DIR)/build/gcc4mbed.mk
+
 
 configdefault.o : config.default
 	@echo Packing $<

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -20,7 +20,7 @@ using std::string;
 // Serial reading module
 // Treats every received line as a command and passes it ( via event call ) to the command dispatcher.
 // The command dispatcher will then ask other modules if they can do something with it
-SerialConsole::SerialConsole( PinName rx_pin, PinName tx_pin, int baud_rate ){
+SerialConsole::SerialConsole( PinName tx_pin, PinName rx_pin, int baud_rate ){
     this->serial = new mbed::Serial( tx_pin, rx_pin );
     this->serial->baud(baud_rate);
 }

--- a/src/modules/communication/SerialConsole.h
+++ b/src/modules/communication/SerialConsole.h
@@ -22,7 +22,7 @@ using std::string;
 
 class SerialConsole : public Module, public StreamOutput {
     public:
-        SerialConsole( PinName rx_pin, PinName tx_pin, int baud_rate );
+        SerialConsole( PinName tx_pin, PinName rx_pin, int baud_rate );
 
         void on_module_loaded();
         void on_serial_char_received();


### PR DESCRIPTION
Adding Bambino200E and Bambino210E support to the makefile. By default
the makefile will still build the binary suitable for running on the
Smoothie2 hardware with its LPC4337 processor. Users with a Bambino
board can modify the following line in the makefile to match their
board:
    BOARD ?= Smoothie2
Instead of modifying the makefile, they can also specify the correct
board on the command line every time they build the binary. For
example:
  make clean all BOARD=Bambino210E

Also updates SerialConsole::SerialConsole() constructor to take the
tx/rx pin designations in the same order as the mbed SDK and as the
existing Smoothie code (ie. Kernel::Kernel()) expected as well.
