### PR TITLE
Fix MRI_ENABLE breaks in makefile

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -19,7 +19,6 @@ GCC4MBED_DIR        := ../gcc4mbed/
 NO_FLOAT_SCANF      := 1
 NO_FLOAT_PRINTF     := 0
 LIBS_PREFIX         := configdefault.o
-GCC4MBED_TYPE       := Checked
 OPTIMIZATION        :=  0
 MRI_SEMIHOST_STDIO  ?= 0
 
@@ -67,7 +66,10 @@ endif
 # Disable the secondary console if the MRI debug monitor is enabled so that the secondary UART can be used by
 # MRI instead.
 ifeq "$(MRI_ENABLE)" "1"
-DEFINES := $(subst -DSMOOTHIE_UART_SECONDARY_ENABLE=1,-DSMOOTHIE_UART_SECONDARY_ENABLE=0,$(DEFINES))
+DEFINES       := $(subst -DSMOOTHIE_UART_SECONDARY_ENABLE=1,-DSMOOTHIE_UART_SECONDARY_ENABLE=0,$(DEFINES))
+GCC4MBED_TYPE := Checked
+else
+GCC4MBED_TYPE := Release
 endif
 
 

--- a/src/makefile
+++ b/src/makefile
@@ -21,7 +21,7 @@ NO_FLOAT_PRINTF     := 0
 LIBS_PREFIX         := configdefault.o
 GCC4MBED_TYPE       := Checked
 OPTIMIZATION        :=  0
-MMRI_SEMIHOST_STDIO ?= 0
+MRI_SEMIHOST_STDIO  ?= 0
 
 # Use C++11 features for the checksums
 DEFINES += -DCHECKSUM_USE_CPP


### PR DESCRIPTION
MRI_ENABLE=0 builds would still break on init

I had a bug in my MRI enabling commit which would cause a halt to occur
at the beginning of execution, even if MRI wasn't enabled which isn't
what I wanted. I now throw the gcc4mbed build into Release or Checked
mode based on the MRI_ENABLE setting.

I also had a typo in the name of the MRI_SEMIHOST_STDIO variable.
