### PR TITLE
Thermistor support for shared GPIO and adc only pins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@
 
 # OS specific files
 .DS_Store
+
+
+#eclipse project files
+.cproject
+.project
+

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/PeripheralNames.h
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/PeripheralNames.h
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * CHANGE LOG:
+ * 10/8/2016 marcosfg - added pin names for adc only pins
  */
 #ifndef MBED_PERIPHERALNAMES_H
 #define MBED_PERIPHERALNAMES_H

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/PeripheralNames.h
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/PeripheralNames.h
@@ -45,7 +45,23 @@ typedef enum {
     ADC1_4,
     ADC1_5,
     ADC1_6,
-    ADC1_7
+    ADC1_7,
+	ADC_pin0_0,        // inlcude adc only pin channels
+	ADC_pin0_1,
+	ADC_pin0_2,
+	ADC_pin0_3,
+	ADC_pin0_4,
+	ADC_pin0_5,
+	ADC_pin0_6,
+	ADC_pin0_7,
+	ADC_pin1_0,
+	ADC_pin1_1,
+	ADC_pin1_2,
+	ADC_pin1_3,
+	ADC_pin1_4,
+	ADC_pin1_5,
+	ADC_pin1_6,
+	ADC_pin1_7,
 } ADCName;
 
 typedef enum {

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PinNames.h
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PinNames.h
@@ -29,6 +29,7 @@ typedef enum {
 
 #define PORT_SHIFT  5
 #define NO_GPIO     15
+#define NO_PORT     0xFF
 
 // On the LPC43xx the MCU pin name and the GPIO pin name are not the same.
 // Encode SCU and GPIO offsets as a pin identifier
@@ -663,6 +664,23 @@ typedef enum {
     DAC0 = P4_4,      // J8-6*    J8-6*   S3-5    S3-5
                       // (*)  if DAC0 is configured, ADC4 is not available
                       // (**) ADC5 requires JP2 mod
+
+	adc0_0 = MBED_PIN(NO_PORT, 0, NO_GPIO, 0),
+	adc0_1 = MBED_PIN(NO_PORT, 1, NO_GPIO, 0),
+	adc0_2 = MBED_PIN(NO_PORT, 2, NO_GPIO, 0),
+	adc0_3 = MBED_PIN(NO_PORT, 3, NO_GPIO, 0),
+	adc0_4 = MBED_PIN(NO_PORT, 4, NO_GPIO, 0),
+	adc0_5 = MBED_PIN(NO_PORT, 5, NO_GPIO, 0),
+	adc0_6 = MBED_PIN(NO_PORT, 6, NO_GPIO, 0),
+	adc0_7 = MBED_PIN(NO_PORT, 7, NO_GPIO, 0),
+	adc1_0 = MBED_PIN(NO_PORT, 8, NO_GPIO, 0),
+	adc1_1 = MBED_PIN(NO_PORT, 9, NO_GPIO, 0),
+	adc1_2 = MBED_PIN(NO_PORT, 10, NO_GPIO, 0),
+	adc1_3 = MBED_PIN(NO_PORT, 11, NO_GPIO, 0),
+	adc1_4 = MBED_PIN(NO_PORT, 12, NO_GPIO, 0),
+	adc1_5 = MBED_PIN(NO_PORT, 13, NO_GPIO, 0),
+	adc1_6 = MBED_PIN(NO_PORT, 14, NO_GPIO, 0),
+	adc1_7 = MBED_PIN(NO_PORT, 15, NO_GPIO, 0),
 
     // USB pins
     //                   210E    210     200E    200

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PinNames.h
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PinNames.h
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * CHANGE LOG:
+ * 10/8/2016 marcosfg - added pin names for adc only pins
  */
 #ifndef MBED_PINNAMES_H
 #define MBED_PINNAMES_H

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
@@ -30,6 +30,7 @@ typedef enum {
 
 #define PORT_SHIFT  5
 #define NO_GPIO     15
+#define NO_PORT     0xFF
 
 // On the LPC43xx the MCU pin name and the GPIO pin name are not the same.
 // Encode SCU and GPIO offsets as a pin identifier
@@ -503,6 +504,25 @@ typedef enum {
     LED2 = LED_BLUE,
     LED3 = LED_GREEN,
     LED4 = LED_RED,
+
+	// Analog Only pins
+
+	adc0_0 = MBED_PIN(NO_PORT, 0, NO_GPIO, 0),
+	adc0_1 = MBED_PIN(NO_PORT, 1, NO_GPIO, 0),
+	adc0_2 = MBED_PIN(NO_PORT, 2, NO_GPIO, 0),
+	adc0_3 = MBED_PIN(NO_PORT, 3, NO_GPIO, 0),
+	adc0_4 = MBED_PIN(NO_PORT, 4, NO_GPIO, 0),
+	adc0_5 = MBED_PIN(NO_PORT, 5, NO_GPIO, 0),
+	adc0_6 = MBED_PIN(NO_PORT, 6, NO_GPIO, 0),
+	adc0_7 = MBED_PIN(NO_PORT, 7, NO_GPIO, 0),
+	adc1_0 = MBED_PIN(NO_PORT, 8, NO_GPIO, 0),
+	adc1_1 = MBED_PIN(NO_PORT, 9, NO_GPIO, 0),
+	adc1_2 = MBED_PIN(NO_PORT, 10, NO_GPIO, 0),
+	adc1_3 = MBED_PIN(NO_PORT, 11, NO_GPIO, 0),
+	adc1_4 = MBED_PIN(NO_PORT, 12, NO_GPIO, 0),
+	adc1_5 = MBED_PIN(NO_PORT, 13, NO_GPIO, 0),
+	adc1_6 = MBED_PIN(NO_PORT, 14, NO_GPIO, 0),
+	adc1_7 = MBED_PIN(NO_PORT, 15, NO_GPIO, 0),
 
     // ---------- End of LPCXpresso 4337 pins ----------
 } PinName;

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * CHANGE LOG:
+ * 10/8/2016 marcosfg - added pin names for adc only pins
  */
 
 #ifndef MBED_PINNAMES_H

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  *
  * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ *
+ * CHANGE LOG:
+ * 10/8/2016 marcosfg - added pin names for adc only pins
  */
 #include "mbed_assert.h"
 #include "analogin_api.h"

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
@@ -25,110 +25,145 @@
 #define ANALOGIN_MEDIAN_FILTER      1
 
 static inline int div_round_up(int x, int y) {
-  return (x + (y - 1)) / y;
+	return (x + (y - 1)) / y;
 }
 
 static const PinMap PinMap_ADC[] = {
-    {P4_3,  ADC0_0, 0},
-    {P4_1,  ADC0_1, 0},
-    {PF_8,  ADC0_2, 0},
-    {P7_5,  ADC0_3, 0},
-    {P7_4,  ADC0_4, 0},
-    {PF_10, ADC0_5, 0},
-    {PB_6,  ADC0_6, 0},
-    {PC_3,  ADC1_0, 0},
-    {PC_0,  ADC1_1, 0},
-    {PF_9,  ADC1_2, 0},
-    {PF_6,  ADC1_3, 0},
-    {PF_5,  ADC1_4, 0},
-    {PF_11, ADC1_5, 0},
-    {P7_7,  ADC1_6, 0},
-    {PF_7,  ADC1_7, 0},
-    {NC,    NC,     0   }
+		{P4_3,  ADC0_0, 0},
+		{P4_1,  ADC0_1, 0},
+		{PF_8,  ADC0_2, 0},
+		{P7_5,  ADC0_3, 0},
+		{P7_4,  ADC0_4, 0},
+		{PF_10, ADC0_5, 0},
+		{PB_6,  ADC0_6, 0},
+		{PC_3,  ADC1_0, 0},
+		{PC_0,  ADC1_1, 0},
+		{PF_9,  ADC1_2, 0},
+		{PF_6,  ADC1_3, 0},
+		{PF_5,  ADC1_4, 0},
+		{PF_11, ADC1_5, 0},
+		{P7_7,  ADC1_6, 0},
+		{PF_7,  ADC1_7, 0},
+		{adc0_0,  ADC_pin0_0, 0},
+		{adc0_1,  ADC_pin0_1, 0},
+		{adc0_2,  ADC_pin0_2, 0},
+		{adc0_3,  ADC_pin0_3, 0},
+		{adc0_4,  ADC_pin0_4, 0},
+		{adc0_5,  ADC_pin0_5, 0},
+		{adc0_6,  ADC_pin0_6, 0},
+		{adc0_7,  ADC_pin0_7, 0},
+		{adc1_0,  ADC_pin1_0, 0},
+		{adc1_1,  ADC_pin1_1, 0},
+		{adc1_2,  ADC_pin1_2, 0},
+		{adc1_3,  ADC_pin1_3, 0},
+		{adc1_4,  ADC_pin1_4, 0},
+		{adc1_5,  ADC_pin1_5, 0},
+		{adc1_6,  ADC_pin1_6, 0},
+		{adc1_7,  ADC_pin1_7, 0},
+		{NC,    NC,     0   }
 };
 
 void analogin_init(analogin_t *obj, PinName pin) {
-    ADCName name;
+	ADCName name;
 
-    name = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
-    MBED_ASSERT(obj->adc != (LPC_ADC_T *)NC);
+	name = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
+	MBED_ASSERT(obj->adc != (LPC_ADC_T *)NC);
 
-    // Set ADC register, number and channel
-    obj->num = (name >> ADC0_7) ? 1 : 0;
-    obj->ch = name % (ADC0_7 + 1);
-    obj->adc = (LPC_ADC_T *) (obj->num > 0) ? LPC_ADC1 : LPC_ADC0;
+	// Set ADC number
+	if(name < ADC1_0)
+	{
+		obj->num = 0;
+	} else if(name < ADC_pin0_0 && name > ADC0_6)
+	{
+		obj->num = 1;
+	} else if(name < ADC_pin1_1 && name > ADC1_7)
+	{
+		obj->num = 0;
+	} else if(name > ADC_pin0_7)
+	{
+		obj->num = 1;
+	}
 
-    // Reset pin function to GPIO
-    gpio_set(pin);
-    // Select ADC on analog function select register in SCU
-    LPC_SCU->ENAIO[obj->num] |= (1 << obj->ch);
-    
-    // Calculate minimum clock divider
-    //  clkdiv = divider - 1
-    uint32_t PCLK = SystemCoreClock;
-    uint32_t adcRate = 400000;
-    uint32_t clkdiv = div_round_up(PCLK, adcRate) - 1;
-    
-    // Set the generic software-controlled ADC settings
-    obj->adc->CR = (0 << 0)      // SEL: 0 = no channels selected
-                  | (clkdiv << 8) // CLKDIV:
-                  | (0 << 16)     // BURST: 0 = software control
-                  | (1 << 21)     // PDN: 1 = operational
-                  | (0 << 24)     // START: 0 = no start
-                  | (0 << 27);    // EDGE: not applicable
+	//ADC register and channel
+	obj->ch = name % (ADC0_7 + 1);
+	obj->adc = (LPC_ADC_T *) (obj->num > 0) ? LPC_ADC1 : LPC_ADC0;
+
+	// Reset pin function to GPIO if it is a GPIO pin. for adc only pins it is not necessary
+	if(name < ADC_pin0_0)
+	{
+		gpio_set(pin);
+		// Select ADC on analog function select register in SCU
+		LPC_SCU->ENAIO[obj->num] |= (1 << obj->ch);
+	} else {
+		LPC_SCU->ENAIO[obj->num] &= ~(1 << obj->ch);
+	}
+
+	// Calculate minimum clock divider
+	//  clkdiv = divider - 1
+	uint32_t PCLK = SystemCoreClock;
+	uint32_t adcRate = 400000;
+	uint32_t clkdiv = div_round_up(PCLK, adcRate) - 1;
+
+	// Set the generic software-controlled ADC settings
+	obj->adc->CR = (0 << 0)      // SEL: 0 = no channels selected
+                		  | (clkdiv << 8) // CLKDIV:
+						  | (0 << 16)     // BURST: 0 = software control
+						  | (1 << 21)     // PDN: 1 = operational
+						  | (0 << 24)     // START: 0 = no start
+						  | (0 << 27);    // EDGE: not applicable
 }
 
 static inline uint32_t adc_read(analogin_t *obj) {
-    uint32_t temp;
-    uint8_t channel = obj->ch;
-    LPC_ADC_T *pADC = obj->adc;
+	uint32_t temp;
+	uint8_t channel = obj->ch;
+	LPC_ADC_T *pADC = obj->adc;
 
-    // Select the appropriate channel and start conversion
-    pADC->CR |= ADC_CR_CH_SEL(channel);
-    temp = pADC->CR & ~ADC_CR_START_MASK;
-    pADC->CR = temp | (ADC_CR_START_MODE_SEL(ADC_START_NOW));
+	// Select the appropriate channel and start conversion
+	pADC->CR |= ADC_CR_CH_SEL(channel);
+	temp = pADC->CR & ~ADC_CR_START_MASK;
+	pADC->CR = temp | (ADC_CR_START_MODE_SEL(ADC_START_NOW));
 
-    // Wait for DONE bit and read data
-    while (!(pADC->STAT & ADC_CR_CH_SEL(channel)));
-    temp = pADC->DR[channel];
+	// Wait for DONE bit and read data
+	while (!(pADC->STAT & ADC_CR_CH_SEL(channel)));
+	temp = pADC->DR[channel];
 
-    // Deselect channel and return result
-    pADC->CR &= ~ADC_CR_START_MASK;
-    pADC->CR &= ~ADC_CR_CH_SEL(channel);
-    return ADC_DR_RESULT(temp);
+	// Deselect channel and return result
+	pADC->CR &= ~ADC_CR_START_MASK;
+	pADC->CR &= ~ADC_CR_CH_SEL(channel);
+	return ADC_DR_RESULT(temp);
 }
 
 static inline void order(uint32_t *a, uint32_t *b) {
-    if (*a > *b) {
-        uint32_t t = *a;
-        *a = *b;
-        *b = t;
-    }
+	if (*a > *b) {
+		uint32_t t = *a;
+		*a = *b;
+		*b = t;
+	}
 }
 
 static inline uint32_t adc_read_u32(analogin_t *obj) {
-    uint32_t value;
+	uint32_t value;
 #if ANALOGIN_MEDIAN_FILTER
-    uint32_t v1 = adc_read(obj);
-    uint32_t v2 = adc_read(obj);
-    uint32_t v3 = adc_read(obj);
-    order(&v1, &v2);
-    order(&v2, &v3);
-    order(&v1, &v2);
-    value = v2;
+	uint32_t v1 = adc_read(obj);
+	uint32_t v2 = adc_read(obj);
+	uint32_t v3 = adc_read(obj);
+	order(&v1, &v2);
+	order(&v2, &v3);
+	order(&v1, &v2);
+	value = v2;
 #else
-    value = adc_read(obj);
+	value = adc_read(obj);
 #endif
-    return value;
+	return value;
 }
 
 uint16_t analogin_read_u16(analogin_t *obj) {
-    uint32_t value = adc_read_u32(obj);
+	uint32_t value = adc_read_u32(obj);
 
-    return (value << 6) | ((value >> 4) & 0x003F); // 10 bit
+	return (value << 6) | ((value >> 4) & 0x003F); // 10 bit
 }
 
 float analogin_read(analogin_t *obj) {
-    uint32_t value = adc_read_u32(obj);
-    return (float)value * (1.0f / (float)ADC_RANGE);
+	uint32_t value = adc_read_u32(obj);
+	return (float)value * (1.0f / (float)ADC_RANGE);
 }

--- a/src/config.default
+++ b/src/config.default
@@ -24,7 +24,7 @@ acceleration 100
 # Hotend temperature control configuration
 temperature_control.hotend.enable            true             # Whether to activate this ( "hotend" ) module at all.
                                                               # All configuration is ignored if false.
-temperature_control.hotend.thermistor_pin    0.23             # Pin for the thermistor to read
+temperature_control.hotend.thermistor_pin    adc.5             # Pin for the thermistor to read
 temperature_control.hotend.heater_pin        2.7              # Pin that controls the heater, set to nc if a readonly thermistor is being defined
 temperature_control.hotend.thermistor        EPCOS100K        # see http://smoothieware.org/temperaturecontrol#toc5
 #temperature_control.hotend.beta             4066             # or set the beta value

--- a/src/libs/Adc.cpp
+++ b/src/libs/Adc.cpp
@@ -19,12 +19,14 @@ using namespace std;
 // TODO : Having the same name is confusing, should change that
 
 Adc::Adc(){
-    this->analogin = new AnalogIn(P4_3);
+    //this->analogin = new AnalogIn(P4_3);
     // TOADDBACK this->adc = new ADC(1000, 1);
 }
 
 // Enables ADC on a given pin
 void Adc::enable_pin(Pin* pin){
+	PinName pin_name = this->_pin_to_pinname(pin);
+	this->analogin = new AnalogIn(pin_name);
     /* TOADDBACK PinName pin_name = this->_pin_to_pinname(pin);
     this->adc->burst(1);
     this->adc->setup(pin_name,1);
@@ -39,6 +41,7 @@ unsigned int Adc::read(Pin* pin){
 
 // Convert a smoothie Pin into a mBed Pin
 PinName Adc::_pin_to_pinname(Pin* pin){
+	return pin->getPinName();
     /* TOADDBACK if( pin->port == LPC_GPIO0 && pin->pin == 23 ){
         return p15;
     }else if( pin->port == LPC_GPIO0 && pin->pin == 24 ){

--- a/src/libs/Adc.h
+++ b/src/libs/Adc.h
@@ -25,6 +25,8 @@ class Adc {
 
         AnalogIn* analogin;
         // TOADDBACK ADC* adc;
+
+        int get_max_value() const { return 65536;}    //Assuming 16bit reading from mbed
 };
 
 

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -10,7 +10,7 @@
 #include "libs/Config.h"
 #include "libs/nuts_bolts.h"
 #include "libs/SlowTicker.h"
-//#include "libs/Adc.h"
+#include "libs/Adc.h"
 #include "libs/StreamOutputPool.h"
 //#include <mri.h>
 #include "checksumm.h"
@@ -75,7 +75,7 @@ Kernel::Kernel(){
     this->config->config_cache_load();
 
     // ADC reading
-    //this->adc = new Adc();
+    this->adc = new Adc();
 
     // For slow repeteative tasks
     this->add_module( this->slow_ticker = new SlowTicker());

--- a/src/libs/Pin.cpp
+++ b/src/libs/Pin.cpp
@@ -28,10 +28,32 @@ Pin* Pin::from_string(std::string value){
     char* cn = NULL;
     valid= true;
 
+    //initialize adc only vars
+    adc_only = false;
+    adc_channel = 0xff;
+
+    //verify if it is an analog only pin
+    std::size_t found = value.find("adc");
+    if (found!=std::string::npos) adc_only = true;
+
+    if(adc_only)
+    {
+    	std::string channelStr = value.substr (4);
+    	cs = channelStr.c_str();
+    	adc_channel = strtol(cs, &cn, 10);
+
+    	PinName adc_pins[16] = {adc0_0,adc0_1,adc0_2,adc0_3,adc0_4,adc0_5,adc0_6,adc0_7,adc1_0,adc1_1,adc1_2,adc1_3,adc1_4,adc1_5,adc1_6,adc1_7};
+    	this->pinName = adc_pins[adc_channel];
+
+    	return this;
+    }
+
+
     // grab first integer as port. pointer to first non-digit goes in cn
-    port_number = strtol(cs, &cn, 10);
+    port_number = strtol(cs, &cn, 16); //allow hexadecimal portnumbes
+
     // if cn > cs then strtol read at least one digit
-    if ((cn > cs) && (port_number <= 7)){
+    if ((cn > cs) && (port_number <= 15)){
         // if the char after the first integer is a . then we should expect a pin index next
         if (*cn == '.'){
             // move pointer to first digit (hopefully) of pin index
@@ -45,6 +67,7 @@ Pin* Pin::from_string(std::string value){
             // Find the pin
             if( pins.count((port_number<<8)+pin) > 0 ){
                 this->mbed_pin = new DigitalInOut( pins[(port_number<<8)+pin] );
+                this->pinName = pins[(port_number<<8)+pin];
             }
 
             // if strtol read some numbers, cn will point to the first non-digit

--- a/src/libs/Pin.h
+++ b/src/libs/Pin.h
@@ -9,78 +9,87 @@
 #include "PinNames.h"
 
 namespace mbed {
-    class PwmOut;
-    class InterruptIn;
+class PwmOut;
+class InterruptIn;
 }
 
 #include "mbed.h"
 
 class Pin {
-    public:
-        Pin();
+public:
+	Pin();
 
-        Pin* from_string(std::string value);
+	Pin* from_string(std::string value);
 
-        inline bool connected(){
-            return this->valid;
-        }
+	inline bool connected(){
+		return this->valid;
+	}
 
-        inline bool equals(const Pin& other) const {
-            //return (this->pin == other.pin) && (this->port == other.port);
-            return false;
-        }
+	inline bool equals(const Pin& other) const {
+		//return (this->pin == other.pin) && (this->port == other.port);
+		return false;
+	}
 
-        inline Pin* as_output(){
-            if (this->valid)
-                this->mbed_pin->output(); 
-            return this;
-        }
+	inline Pin* as_output(){
+		if (this->valid)
+			this->mbed_pin->output();
+		return this;
+	}
 
-        inline Pin* as_input(){
-            if (this->valid)
-                this->mbed_pin->input();
-            return this;
-        }
+	inline Pin* as_input(){
+		if (this->valid)
+			this->mbed_pin->input();
+		return this;
+	}
 
-        Pin* as_open_drain(void);
+	Pin* as_open_drain(void);
 
-        Pin* as_repeater(void);
+	Pin* as_repeater(void);
 
-        Pin* pull_up(void);
+	Pin* pull_up(void);
 
-        Pin* pull_down(void);
+	Pin* pull_down(void);
 
-        Pin* pull_none(void);
+	Pin* pull_none(void);
 
-        inline bool get(){
-            if (!this->valid) return false;
-            return this->inverting ^ ( (bool)this->mbed_pin->read() );
-        }
+	inline bool get(){
+		if (!this->valid) return false;
+		return this->inverting ^ ( (bool)this->mbed_pin->read() );
+	}
 
-        inline void set(bool value)
-        {
-            if (!this->valid) return;
-            if ( this->inverting ^ value ){
-                this->mbed_pin->write(1);
-            }else{
-                this->mbed_pin->write(0);
-            }
-        }
+	inline void set(bool value)
+	{
+		if (!this->valid) return;
+		if ( this->inverting ^ value ){
+			this->mbed_pin->write(1);
+		}else{
+			this->mbed_pin->write(0);
+		}
+	}
 
-        mbed::PwmOut *hardware_pwm();
+	mbed::PwmOut *hardware_pwm();
 
-        mbed::InterruptIn *interrupt_pin();
+	mbed::InterruptIn *interrupt_pin();
 
-        bool is_inverting() const { return inverting; }
-        void set_inverting(bool f) { inverting= f; }
+	bool is_inverting() const { return inverting; }
+	void set_inverting(bool f) { inverting= f; }
 
-        // these should be private, and use getters
-        DigitalInOut* mbed_pin;
+	// these should be private, and use getters
+	DigitalInOut* mbed_pin;
 
-        struct {
-            bool inverting:1;
-            bool valid:1;
-        };
+	struct {
+		bool inverting:1;
+		bool valid:1;
+		bool adc_only:1;    //true if adc only pin
+		int adc_channel:8;    //adc channel
+	};
+
+	//getter to access to mbed pinName
+	PinName getPinName() {return pinName; }
+
+private:
+	//Added pinName
+	PinName pinName;
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 /* Test which brings default HelloWorld project from mbed online compiler
    to be built under GCC.
-*/
+ */
 #include "mbed.h"
 #include "Kernel.h"
 #include "SwitchPool.h"
@@ -10,36 +10,48 @@
 #include "Config.h"
 #include "StreamOutputPool.h"
 
+DigitalOut leds[4] = {
+		DigitalOut(LED1),
+		DigitalOut(LED2),
+		DigitalOut(LED3),
+		DigitalOut(LED4)
+};
+
 int main() {
 
-    // Kernel creates modules, and receives and dispatches events between them
-    Kernel* kernel = new Kernel();
+	int cnt = 0;
 
-    // Say hello ( TODO : Add back version and all )
-    kernel->streams->printf("Smoothie2 dev\n");
+	// Kernel creates modules, and receives and dispatches events between them
+	Kernel* kernel = new Kernel();
 
-    // Create and add main modules
-    kernel->add_module( new Endstops() );
-    kernel->add_module( new Laser() );
+	// Say hello ( TODO : Add back version and all )
+	kernel->streams->printf("Smoothie2 dev\n");
 
-    // Create all Switch modules
-    SwitchPool *sp= new SwitchPool();
-    sp->load_tools();
-    delete sp;
+	// Create and add main modules
+	kernel->add_module( new Endstops() );
+	kernel->add_module( new Laser() );
 
-    // TOADDBACK 
-    // Create all TemperatureControl modules. Note order is important here must be after extruder so Tn as a parameter will get executed first
-    // TemperatureControlPool *tp= new TemperatureControlPool();
-    // tp->load_tools();
-    // delete tp;
+	// Create all Switch modules
+	SwitchPool *sp= new SwitchPool();
+	sp->load_tools();
+	delete sp;
 
-    // Clear the configuration cache as it is no longer needed
-    kernel->config->config_cache_clear();
+	// Create all TemperatureControl modules. Note order is important here must be after extruder so Tn as a parameter will get executed first
+	TemperatureControlPool *tp= new TemperatureControlPool();
+	tp->load_tools();
+	delete tp;
 
-    // Main loop
-    while(1){
-        THEKERNEL->call_event(ON_MAIN_LOOP);
-        THEKERNEL->call_event(ON_IDLE);
-    }
+	// Clear the configuration cache as it is no longer needed
+	kernel->config->config_cache_clear();
+
+	// Main loop
+	while(1){
+		if(THEKERNEL->is_using_leds()) {
+			// flash led 2 to show we are alive
+			leds[0]= (cnt++ & 0x1000) ? 1 : 0;
+		}
+		THEKERNEL->call_event(ON_MAIN_LOOP);
+		THEKERNEL->call_event(ON_IDLE);
+	}
 
 }

--- a/src/makefile
+++ b/src/makefile
@@ -2,7 +2,7 @@
 # Can be one of: Smoothie2Proto1 (**current default**)
 #                Bambino210E
 #                Bambino200E
-BOARD ?= Smoothie2Proto1
+BOARD ?= Bambino210E
 
 # Set MRI_ENABLE to a value of 1 to enable the MRI debug monitor on the secondary UART.
 MRI_ENABLE ?= 0
@@ -13,7 +13,7 @@ MRI_BREAK_ON_INIT ?= 1
 # Can set OPTIMIZATION to 0 to disable compiler optimizations. This makes debugging easier but the code will run more
 # slowly. It may run so slowly that it fails to execute properly since some routines (ie. step tickers) are
 # time sensitive.
-# OPTIMIZATION        :=  0
+OPTIMIZATION        :=  0
 
 
 

--- a/src/modules/tools/temperaturecontrol/Thermistor.cpp
+++ b/src/modules/tools/temperaturecontrol/Thermistor.cpp
@@ -124,7 +124,7 @@ void Thermistor::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
 
     // Thermistor pin for ADC readings
     this->thermistor_pin.from_string(THEKERNEL->config->value(module_checksum, name_checksum, thermistor_pin_checksum )->required()->as_string());
-    // TOADDBACK THEKERNEL->adc->enable_pin(&thermistor_pin);
+    THEKERNEL->adc->enable_pin(&thermistor_pin);
 
     // specify the three Steinhart-Hart coefficients
     // specified as three comma separated floats, no spaces
@@ -251,7 +251,7 @@ void Thermistor::get_raw()
     }
 
     int adc_value= new_thermistor_reading();
-    const uint32_t max_adc_value= 0; // TOADDBACK THEKERNEL->adc->get_max_value();
+    const uint32_t max_adc_value= THEKERNEL->adc->get_max_value();
 
      // resistance of the thermistor in ohms
     float r = r2 / (((float)max_adc_value / adc_value) - 1.0F);
@@ -282,7 +282,7 @@ void Thermistor::get_raw()
 
 float Thermistor::adc_value_to_temperature(uint32_t adc_value)
 {
-    const uint32_t max_adc_value= 0; //TOADDBACK THEKERNEL->adc->get_max_value();
+    const uint32_t max_adc_value= THEKERNEL->adc->get_max_value();
     if ((adc_value >= max_adc_value) || (adc_value == 0))
         return infinityf();
 


### PR DESCRIPTION
This pull request includes changes to the smoothie2 firmware to support thermistor readings, namely in adc-only pins.
- Changed "libs/Pin.cpp" to store the PinName when creating a pin from string. I have also included the support for port numbers higher than 7.
- In "libs/Adc.cpp", a new mbed AnalogIn is create using the PinName stored by Pin.cpp
- Changed mbed anallog_api, PinNames and PeripheralNames to support adc-only pins
