### PR TITLE
ADC Busrt Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@
 
 # OS specific files
 .DS_Store
+
+
+#eclipse project files
+.cproject
+.project
+

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/PeripheralNames.h
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/PeripheralNames.h
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * CHANGE LOG:
+ * 10/8/2016 marcosfg - added pin names for adc only pins
  */
 #ifndef MBED_PERIPHERALNAMES_H
 #define MBED_PERIPHERALNAMES_H

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/PeripheralNames.h
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/PeripheralNames.h
@@ -45,7 +45,23 @@ typedef enum {
     ADC1_4,
     ADC1_5,
     ADC1_6,
-    ADC1_7
+    ADC1_7,
+	ADC_pin0_0,        // inlcude adc only pin channels
+	ADC_pin0_1,
+	ADC_pin0_2,
+	ADC_pin0_3,
+	ADC_pin0_4,
+	ADC_pin0_5,
+	ADC_pin0_6,
+	ADC_pin0_7,
+	ADC_pin1_0,
+	ADC_pin1_1,
+	ADC_pin1_2,
+	ADC_pin1_3,
+	ADC_pin1_4,
+	ADC_pin1_5,
+	ADC_pin1_6,
+	ADC_pin1_7,
 } ADCName;
 
 typedef enum {

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PinNames.h
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PinNames.h
@@ -29,6 +29,7 @@ typedef enum {
 
 #define PORT_SHIFT  5
 #define NO_GPIO     15
+#define NO_PORT     0xFF
 
 // On the LPC43xx the MCU pin name and the GPIO pin name are not the same.
 // Encode SCU and GPIO offsets as a pin identifier
@@ -663,6 +664,23 @@ typedef enum {
     DAC0 = P4_4,      // J8-6*    J8-6*   S3-5    S3-5
                       // (*)  if DAC0 is configured, ADC4 is not available
                       // (**) ADC5 requires JP2 mod
+
+	adc0_0 = MBED_PIN(NO_PORT, 0, NO_GPIO, 0),
+	adc0_1 = MBED_PIN(NO_PORT, 1, NO_GPIO, 0),
+	adc0_2 = MBED_PIN(NO_PORT, 2, NO_GPIO, 0),
+	adc0_3 = MBED_PIN(NO_PORT, 3, NO_GPIO, 0),
+	adc0_4 = MBED_PIN(NO_PORT, 4, NO_GPIO, 0),
+	adc0_5 = MBED_PIN(NO_PORT, 5, NO_GPIO, 0),
+	adc0_6 = MBED_PIN(NO_PORT, 6, NO_GPIO, 0),
+	adc0_7 = MBED_PIN(NO_PORT, 7, NO_GPIO, 0),
+	adc1_0 = MBED_PIN(NO_PORT, 8, NO_GPIO, 0),
+	adc1_1 = MBED_PIN(NO_PORT, 9, NO_GPIO, 0),
+	adc1_2 = MBED_PIN(NO_PORT, 10, NO_GPIO, 0),
+	adc1_3 = MBED_PIN(NO_PORT, 11, NO_GPIO, 0),
+	adc1_4 = MBED_PIN(NO_PORT, 12, NO_GPIO, 0),
+	adc1_5 = MBED_PIN(NO_PORT, 13, NO_GPIO, 0),
+	adc1_6 = MBED_PIN(NO_PORT, 14, NO_GPIO, 0),
+	adc1_7 = MBED_PIN(NO_PORT, 15, NO_GPIO, 0),
 
     // USB pins
     //                   210E    210     200E    200

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PinNames.h
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PinNames.h
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * CHANGE LOG:
+ * 10/8/2016 marcosfg - added pin names for adc only pins
  */
 #ifndef MBED_PINNAMES_H
 #define MBED_PINNAMES_H

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
@@ -30,6 +30,7 @@ typedef enum {
 
 #define PORT_SHIFT  5
 #define NO_GPIO     15
+#define NO_PORT     0xFF
 
 // On the LPC43xx the MCU pin name and the GPIO pin name are not the same.
 // Encode SCU and GPIO offsets as a pin identifier
@@ -503,6 +504,25 @@ typedef enum {
     LED2 = LED_BLUE,
     LED3 = LED_GREEN,
     LED4 = LED_RED,
+
+	// Analog Only pins
+
+	adc0_0 = MBED_PIN(NO_PORT, 0, NO_GPIO, 0),
+	adc0_1 = MBED_PIN(NO_PORT, 1, NO_GPIO, 0),
+	adc0_2 = MBED_PIN(NO_PORT, 2, NO_GPIO, 0),
+	adc0_3 = MBED_PIN(NO_PORT, 3, NO_GPIO, 0),
+	adc0_4 = MBED_PIN(NO_PORT, 4, NO_GPIO, 0),
+	adc0_5 = MBED_PIN(NO_PORT, 5, NO_GPIO, 0),
+	adc0_6 = MBED_PIN(NO_PORT, 6, NO_GPIO, 0),
+	adc0_7 = MBED_PIN(NO_PORT, 7, NO_GPIO, 0),
+	adc1_0 = MBED_PIN(NO_PORT, 8, NO_GPIO, 0),
+	adc1_1 = MBED_PIN(NO_PORT, 9, NO_GPIO, 0),
+	adc1_2 = MBED_PIN(NO_PORT, 10, NO_GPIO, 0),
+	adc1_3 = MBED_PIN(NO_PORT, 11, NO_GPIO, 0),
+	adc1_4 = MBED_PIN(NO_PORT, 12, NO_GPIO, 0),
+	adc1_5 = MBED_PIN(NO_PORT, 13, NO_GPIO, 0),
+	adc1_6 = MBED_PIN(NO_PORT, 14, NO_GPIO, 0),
+	adc1_7 = MBED_PIN(NO_PORT, 15, NO_GPIO, 0),
 
     // ---------- End of LPCXpresso 4337 pins ----------
 } PinName;

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * CHANGE LOG:
+ * 10/8/2016 marcosfg - added pin names for adc only pins
  */
 
 #ifndef MBED_PINNAMES_H

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  *
  * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ *
+ * CHANGE LOG:
+ * 10/8/2016 marcosfg - added pin names for adc only pins
  */
 #include "mbed_assert.h"
 #include "analogin_api.h"

--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
@@ -25,110 +25,145 @@
 #define ANALOGIN_MEDIAN_FILTER      1
 
 static inline int div_round_up(int x, int y) {
-  return (x + (y - 1)) / y;
+	return (x + (y - 1)) / y;
 }
 
 static const PinMap PinMap_ADC[] = {
-    {P4_3,  ADC0_0, 0},
-    {P4_1,  ADC0_1, 0},
-    {PF_8,  ADC0_2, 0},
-    {P7_5,  ADC0_3, 0},
-    {P7_4,  ADC0_4, 0},
-    {PF_10, ADC0_5, 0},
-    {PB_6,  ADC0_6, 0},
-    {PC_3,  ADC1_0, 0},
-    {PC_0,  ADC1_1, 0},
-    {PF_9,  ADC1_2, 0},
-    {PF_6,  ADC1_3, 0},
-    {PF_5,  ADC1_4, 0},
-    {PF_11, ADC1_5, 0},
-    {P7_7,  ADC1_6, 0},
-    {PF_7,  ADC1_7, 0},
-    {NC,    NC,     0   }
+		{P4_3,  ADC0_0, 0},
+		{P4_1,  ADC0_1, 0},
+		{PF_8,  ADC0_2, 0},
+		{P7_5,  ADC0_3, 0},
+		{P7_4,  ADC0_4, 0},
+		{PF_10, ADC0_5, 0},
+		{PB_6,  ADC0_6, 0},
+		{PC_3,  ADC1_0, 0},
+		{PC_0,  ADC1_1, 0},
+		{PF_9,  ADC1_2, 0},
+		{PF_6,  ADC1_3, 0},
+		{PF_5,  ADC1_4, 0},
+		{PF_11, ADC1_5, 0},
+		{P7_7,  ADC1_6, 0},
+		{PF_7,  ADC1_7, 0},
+		{adc0_0,  ADC_pin0_0, 0},
+		{adc0_1,  ADC_pin0_1, 0},
+		{adc0_2,  ADC_pin0_2, 0},
+		{adc0_3,  ADC_pin0_3, 0},
+		{adc0_4,  ADC_pin0_4, 0},
+		{adc0_5,  ADC_pin0_5, 0},
+		{adc0_6,  ADC_pin0_6, 0},
+		{adc0_7,  ADC_pin0_7, 0},
+		{adc1_0,  ADC_pin1_0, 0},
+		{adc1_1,  ADC_pin1_1, 0},
+		{adc1_2,  ADC_pin1_2, 0},
+		{adc1_3,  ADC_pin1_3, 0},
+		{adc1_4,  ADC_pin1_4, 0},
+		{adc1_5,  ADC_pin1_5, 0},
+		{adc1_6,  ADC_pin1_6, 0},
+		{adc1_7,  ADC_pin1_7, 0},
+		{NC,    NC,     0   }
 };
 
 void analogin_init(analogin_t *obj, PinName pin) {
-    ADCName name;
+	ADCName name;
 
-    name = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
-    MBED_ASSERT(obj->adc != (LPC_ADC_T *)NC);
+	name = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
+	MBED_ASSERT(obj->adc != (LPC_ADC_T *)NC);
 
-    // Set ADC register, number and channel
-    obj->num = (name >> ADC0_7) ? 1 : 0;
-    obj->ch = name % (ADC0_7 + 1);
-    obj->adc = (LPC_ADC_T *) (obj->num > 0) ? LPC_ADC1 : LPC_ADC0;
+	// Set ADC number
+	if(name < ADC1_0)
+	{
+		obj->num = 0;
+	} else if(name < ADC_pin0_0 && name > ADC0_6)
+	{
+		obj->num = 1;
+	} else if(name < ADC_pin1_1 && name > ADC1_7)
+	{
+		obj->num = 0;
+	} else if(name > ADC_pin0_7)
+	{
+		obj->num = 1;
+	}
 
-    // Reset pin function to GPIO
-    gpio_set(pin);
-    // Select ADC on analog function select register in SCU
-    LPC_SCU->ENAIO[obj->num] |= (1 << obj->ch);
-    
-    // Calculate minimum clock divider
-    //  clkdiv = divider - 1
-    uint32_t PCLK = SystemCoreClock;
-    uint32_t adcRate = 400000;
-    uint32_t clkdiv = div_round_up(PCLK, adcRate) - 1;
-    
-    // Set the generic software-controlled ADC settings
-    obj->adc->CR = (0 << 0)      // SEL: 0 = no channels selected
-                  | (clkdiv << 8) // CLKDIV:
-                  | (0 << 16)     // BURST: 0 = software control
-                  | (1 << 21)     // PDN: 1 = operational
-                  | (0 << 24)     // START: 0 = no start
-                  | (0 << 27);    // EDGE: not applicable
+	//ADC register and channel
+	obj->ch = name % (ADC0_7 + 1);
+	obj->adc = (LPC_ADC_T *) (obj->num > 0) ? LPC_ADC1 : LPC_ADC0;
+
+	// Reset pin function to GPIO if it is a GPIO pin. for adc only pins it is not necessary
+	if(name < ADC_pin0_0)
+	{
+		gpio_set(pin);
+		// Select ADC on analog function select register in SCU
+		LPC_SCU->ENAIO[obj->num] |= (1 << obj->ch);
+	} else {
+		LPC_SCU->ENAIO[obj->num] &= ~(1 << obj->ch);
+	}
+
+	// Calculate minimum clock divider
+	//  clkdiv = divider - 1
+	uint32_t PCLK = SystemCoreClock;
+	uint32_t adcRate = 400000;
+	uint32_t clkdiv = div_round_up(PCLK, adcRate) - 1;
+
+	// Set the generic software-controlled ADC settings
+	obj->adc->CR = (0 << 0)      // SEL: 0 = no channels selected
+                		  | (clkdiv << 8) // CLKDIV:
+						  | (0 << 16)     // BURST: 0 = software control
+						  | (1 << 21)     // PDN: 1 = operational
+						  | (0 << 24)     // START: 0 = no start
+						  | (0 << 27);    // EDGE: not applicable
 }
 
 static inline uint32_t adc_read(analogin_t *obj) {
-    uint32_t temp;
-    uint8_t channel = obj->ch;
-    LPC_ADC_T *pADC = obj->adc;
+	uint32_t temp;
+	uint8_t channel = obj->ch;
+	LPC_ADC_T *pADC = obj->adc;
 
-    // Select the appropriate channel and start conversion
-    pADC->CR |= ADC_CR_CH_SEL(channel);
-    temp = pADC->CR & ~ADC_CR_START_MASK;
-    pADC->CR = temp | (ADC_CR_START_MODE_SEL(ADC_START_NOW));
+	// Select the appropriate channel and start conversion
+	pADC->CR |= ADC_CR_CH_SEL(channel);
+	temp = pADC->CR & ~ADC_CR_START_MASK;
+	pADC->CR = temp | (ADC_CR_START_MODE_SEL(ADC_START_NOW));
 
-    // Wait for DONE bit and read data
-    while (!(pADC->STAT & ADC_CR_CH_SEL(channel)));
-    temp = pADC->DR[channel];
+	// Wait for DONE bit and read data
+	while (!(pADC->STAT & ADC_CR_CH_SEL(channel)));
+	temp = pADC->DR[channel];
 
-    // Deselect channel and return result
-    pADC->CR &= ~ADC_CR_START_MASK;
-    pADC->CR &= ~ADC_CR_CH_SEL(channel);
-    return ADC_DR_RESULT(temp);
+	// Deselect channel and return result
+	pADC->CR &= ~ADC_CR_START_MASK;
+	pADC->CR &= ~ADC_CR_CH_SEL(channel);
+	return ADC_DR_RESULT(temp);
 }
 
 static inline void order(uint32_t *a, uint32_t *b) {
-    if (*a > *b) {
-        uint32_t t = *a;
-        *a = *b;
-        *b = t;
-    }
+	if (*a > *b) {
+		uint32_t t = *a;
+		*a = *b;
+		*b = t;
+	}
 }
 
 static inline uint32_t adc_read_u32(analogin_t *obj) {
-    uint32_t value;
+	uint32_t value;
 #if ANALOGIN_MEDIAN_FILTER
-    uint32_t v1 = adc_read(obj);
-    uint32_t v2 = adc_read(obj);
-    uint32_t v3 = adc_read(obj);
-    order(&v1, &v2);
-    order(&v2, &v3);
-    order(&v1, &v2);
-    value = v2;
+	uint32_t v1 = adc_read(obj);
+	uint32_t v2 = adc_read(obj);
+	uint32_t v3 = adc_read(obj);
+	order(&v1, &v2);
+	order(&v2, &v3);
+	order(&v1, &v2);
+	value = v2;
 #else
-    value = adc_read(obj);
+	value = adc_read(obj);
 #endif
-    return value;
+	return value;
 }
 
 uint16_t analogin_read_u16(analogin_t *obj) {
-    uint32_t value = adc_read_u32(obj);
+	uint32_t value = adc_read_u32(obj);
 
-    return (value << 6) | ((value >> 4) & 0x003F); // 10 bit
+	return (value << 6) | ((value >> 4) & 0x003F); // 10 bit
 }
 
 float analogin_read(analogin_t *obj) {
-    uint32_t value = adc_read_u32(obj);
-    return (float)value * (1.0f / (float)ADC_RANGE);
+	uint32_t value = adc_read_u32(obj);
+	return (float)value * (1.0f / (float)ADC_RANGE);
 }

--- a/src/config.default
+++ b/src/config.default
@@ -24,7 +24,7 @@ acceleration 100
 # Hotend temperature control configuration
 temperature_control.hotend.enable            true             # Whether to activate this ( "hotend" ) module at all.
                                                               # All configuration is ignored if false.
-temperature_control.hotend.thermistor_pin    0.23             # Pin for the thermistor to read
+temperature_control.hotend.thermistor_pin    adc.5             # Pin for the thermistor to read
 temperature_control.hotend.heater_pin        2.7              # Pin that controls the heater, set to nc if a readonly thermistor is being defined
 temperature_control.hotend.thermistor        EPCOS100K        # see http://smoothieware.org/temperaturecontrol#toc5
 #temperature_control.hotend.beta             4066             # or set the beta value

--- a/src/libs/ADC/BurstADC.cpp
+++ b/src/libs/ADC/BurstADC.cpp
@@ -331,6 +331,7 @@ void BurstADC::interrupt_state(PinName pin, int state) {
 	if (state == 1) {
 		adc->INTEN &= ~0x100;
 		adc->INTEN |= 1 << chan;
+		fprintf(stderr, "ADC Warning. Current Not supporting interrupts in Busrt mode\n");
 		/* Enable the ADC Interrupt */
 		NVIC_EnableIRQ((adc_number>0)?ADC1_IRQn:ADC0_IRQn);
 	} else {

--- a/src/libs/ADC/BurstADC.cpp
+++ b/src/libs/ADC/BurstADC.cpp
@@ -411,7 +411,8 @@ int BurstADC::read(PinName pin) {
 	_adc_data[_pin_to_channel(pin)] &= ~(((uint32_t)0x01 << 31) | ((uint32_t)0x01 << 30));
 	//Return value
 	int pinData = ((_data_of_pin(pin) >> 6) & 0x3FF);
-	return (pinData << 6) | ((pinData >> 4) & 0x003F); // 10 bit;
+	//int returnValue = (pinData << 6) | ((pinData >> 4) & 0x003F); // 10 bit;
+	return pinData;
 }
 
 //Return DONE flag of ADC on pin

--- a/src/libs/ADC/BurstADC.cpp
+++ b/src/libs/ADC/BurstADC.cpp
@@ -1,0 +1,431 @@
+/*
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "BurstADC.h"
+
+//using namespace mbed;
+
+BurstADC *BurstADC::instance;
+
+static inline int div_round_up(int x, int y) {
+	return (x + (y - 1)) / y;
+}
+
+static const PinMap PinMap_ADC[] = {
+		{P4_3,  ADC0_0, 0},
+		{P4_1,  ADC0_1, 0},
+		{PF_8,  ADC0_2, 0},
+		{P7_5,  ADC0_3, 0},
+		{P7_4,  ADC0_4, 0},
+		{PF_10, ADC0_5, 0},
+		{PB_6,  ADC0_6, 0},
+		{PC_3,  ADC1_0, 0},
+		{PC_0,  ADC1_1, 0},
+		{PF_9,  ADC1_2, 0},
+		{PF_6,  ADC1_3, 0},
+		{PF_5,  ADC1_4, 0},
+		{PF_11, ADC1_5, 0},
+		{P7_7,  ADC1_6, 0},
+		{PF_7,  ADC1_7, 0},
+		{adc0_0,  ADC_pin0_0, 0},
+		{adc0_1,  ADC_pin0_1, 0},
+		{adc0_2,  ADC_pin0_2, 0},
+		{adc0_3,  ADC_pin0_3, 0},
+		{adc0_4,  ADC_pin0_4, 0},
+		{adc0_5,  ADC_pin0_5, 0},
+		{adc0_6,  ADC_pin0_6, 0},
+		{adc0_7,  ADC_pin0_7, 0},
+		{adc1_0,  ADC_pin1_0, 0},
+		{adc1_1,  ADC_pin1_1, 0},
+		{adc1_2,  ADC_pin1_2, 0},
+		{adc1_3,  ADC_pin1_3, 0},
+		{adc1_4,  ADC_pin1_4, 0},
+		{adc1_5,  ADC_pin1_5, 0},
+		{adc1_6,  ADC_pin1_6, 0},
+		{adc1_7,  ADC_pin1_7, 0},
+		{NC,    NC,     0   }
+};
+
+BurstADC::BurstADC(int sample_rate, int cclk_div, int adcNumber)
+{
+	int adc_clk_freq;
+
+	adc_number = adcNumber;
+	adc = (LPC_ADC_T *) (adc_number > 0) ? LPC_ADC1 : LPC_ADC0;
+
+	//Check adc clock
+	adc_clk_freq=CLKS_PER_SAMPLE*sample_rate;
+	if(adc_clk_freq > MAX_ADC_CLOCK)
+		adc_clk_freq = MAX_ADC_CLOCK;
+
+
+	// calculate minimum clock divider
+	int PCLK = SystemCoreClock;
+	int clkdiv = 0;
+	clkdiv = div_round_up(PCLK, adc_clk_freq) - 1;
+
+	if (clkdiv > 0xFF) {
+		printf("ADC Warning: Clock division is %u which is above 255 limit. Re-Setting at limit.\n", clkdiv);
+		clkdiv=0xFF;
+	}
+	if (clkdiv == 0) {
+		printf("ADC Warning: Clock division is 0. Re-Setting to 1.\n");
+		clkdiv=1;
+	}
+
+
+	// Set the generic software-controlled ADC settings
+	adc->CR = (0 << 0)      // SEL: 0 = no channels selected
+							  | (clkdiv << 8) // CLKDIV:
+							  | (0 << 16)     // BURST: 0 = software control
+							  | (0 << 17)     // CLKS: 0 = 11 Clocks/10Bits
+							  | (1 << 21)     // PDN: 1 = operational
+							  | (0 << 24)     // START: 0 = no start
+							  | (0 << 27);    // EDGE: not applicable
+
+	//Default no channels enabled
+	adc->CR &= ~0xFF;
+	//Default NULL global custom isr
+	_adc_g_isr = NULL;
+	//Initialize arrays
+	for (int i=7; i>=0; i--) {
+		_adc_data[i] = 0;
+		_adc_isr[i] = NULL;
+	}
+
+
+	//* Attach IRQ
+	instance = this;
+	NVIC_SetVector((adc_number>0)?ADC1_IRQn:ADC0_IRQn, (uint32_t)&_adcisr);
+
+	//Disable global interrupt
+	adc->INTEN &= ~0x100;
+
+
+
+}
+
+void BurstADC::_adcisr(void)
+{
+	instance->adcisr();
+}
+
+
+void BurstADC::adcisr(void)
+{
+	uint32_t stat;
+	int chan;
+
+	// Read status
+	stat = adc->STAT;
+	//Scan channels for over-run or done and update array
+	if (stat & 0x0101) _adc_data[0] = adc->DR[0];
+	if (stat & 0x0202) _adc_data[1] = adc->DR[1];
+	if (stat & 0x0404) _adc_data[2] = adc->DR[2];
+	if (stat & 0x0808) _adc_data[3] = adc->DR[3];
+	if (stat & 0x1010) _adc_data[4] = adc->DR[4];
+	if (stat & 0x2020) _adc_data[5] = adc->DR[5];
+	if (stat & 0x4040) _adc_data[6] = adc->DR[6];
+	if (stat & 0x8080) _adc_data[7] = adc->DR[7];
+
+	// Channel that triggered interrupt
+	chan = (adc->GDR >> 24) & 0x07;
+	//User defined interrupt handlers
+	if (_adc_isr[chan] != NULL)
+		_adc_isr[chan](_adc_data[chan]);
+	if (_adc_g_isr != NULL)
+		_adc_g_isr(chan, _adc_data[chan]);
+
+	return;
+}
+
+int BurstADC::_pin_to_channel(PinName pin) {
+
+	ADCName name;
+
+	name = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
+
+	int ch = name % (ADC0_7 + 1);
+
+	return ch;
+}
+
+PinName BurstADC::channel_to_pin(int chan) {
+	//LPC43xx has 2 ADC with 8 pins each + 8 adc only pins. Current structure of this function is not suitable
+	PinName a;
+	return a;
+}
+
+
+int BurstADC::channel_to_pin_number(int chan) {
+
+	//LPC43xx has 2 ADC with 8 pins each + 8 adc only pins. Current structure of this function is not suitable
+	return 0;
+}
+
+
+uint32_t BurstADC::_data_of_pin(PinName pin) {
+	//If in burst mode and at least one interrupt enabled then
+	//take all values from _adc_data
+	if (burst() && (adc->INTEN & 0xFF)) {
+		return(_adc_data[_pin_to_channel(pin)]);
+	} else {
+		//Return current register value or last value from interrupt
+		int adcChn = _pin_to_channel(pin);
+
+		switch (adcChn) {
+		case 0:
+			return(adc->INTEN & 0x01?_adc_data[0]:adc->DR[0]);
+		case 1:
+			return(adc->INTEN & 0x02?_adc_data[0]:adc->DR[1]);
+		case 2:
+			return(adc->INTEN & 0x04?_adc_data[0]:adc->DR[2]);
+		case 3:
+			return(adc->INTEN & 0x08?_adc_data[0]:adc->DR[3]);
+		case 4:
+			return(adc->INTEN & 0x10?_adc_data[0]:adc->DR[4]);
+		case 5:
+			return(adc->INTEN & 0x20?_adc_data[0]:adc->DR[5]);
+		case 6:
+			return(adc->INTEN & 0x40?_adc_data[0]:adc->DR[6]);
+		case 7:
+			return(adc->INTEN & 0x80?_adc_data[0]:adc->DR[7]);
+		default:
+			return 0;
+		}
+
+	}
+
+}
+
+//Enable or disable an ADC pin
+void BurstADC::setup(PinName pin, int state) {
+
+	int chan;
+	ADCName name;
+
+	name = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
+	MBED_ASSERT(adc != (LPC_ADC_T *)NC);
+
+	// Set ADC number
+	if(name < ADC1_0)
+	{
+		adc_number = 0;
+	} else if(name < ADC_pin0_0 && name > ADC0_6)
+	{
+		adc_number = 1;
+	} else if(name < ADC_pin1_1 && name > ADC1_7)
+	{
+		adc_number = 0;
+	} else if(name > ADC_pin0_7)
+	{
+		adc_number = 1;
+	}
+
+	// Set ADC register, number and channel
+	adc_number = (name >> ADC0_7) ? 1 : 0;
+	chan = name % (ADC0_7 + 1);
+	adc = (LPC_ADC_T *) (adc_number > 0) ? LPC_ADC1 : LPC_ADC0;
+
+
+	if ((state & 1) == 1) {
+		// Reset pin function to GPIO if it is a GPIO pin.
+		if(name < ADC_pin0_0)
+		{
+			gpio_set(pin);
+			// Select ADC on analog function select register in SCU
+			LPC_SCU->ENAIO[adc_number] |= (1 << chan);
+		} else {//If adc only pin configure GPIO as digital function
+			LPC_SCU->ENAIO[adc_number] &= ~(1 << chan);
+		}
+		//Only one channel can be selected at a time if not in burst mode
+		if (!burst()) adc->CR &= ~0xFF;
+		//Select channel
+		adc->CR |= (1 << chan);
+	}
+	else {
+		// Reset pin function to GPIO if it is a GPIO pin.
+		if(name < ADC_pin0_0)
+		{
+			gpio_set(pin);
+			// Select digital on analog function select register in SCU
+			LPC_SCU->ENAIO[adc_number] &= ~(1 << chan);
+		}
+	}
+
+}
+
+//Return channel enabled/disabled state
+int BurstADC::setup(PinName pin) {
+	int chan;
+
+	chan = _pin_to_channel(pin);
+	return((adc->CR & (1 << chan)) >> chan);
+}
+
+//Select channel already setup
+void BurstADC::select(PinName pin) {
+	int chan;
+
+	//Only one channel can be selected at a time if not in burst mode
+	if (!burst()) adc->CR &= ~0xFF;
+	//Select channel
+	chan = _pin_to_channel(pin);
+	adc->CR |= (1 << chan);
+}
+
+//Enable or disable burst mode
+void BurstADC::burst(int state) {
+
+	if ((state & 1) == 1) {
+		if (startmode(0) != 0)
+			fprintf(stderr, "ADC Warning. startmode is %u. Must be 0 for burst mode.\n", startmode(0));
+		adc->CR |= (1 << 16);
+	}
+	else
+		adc->CR &= ~(1 << 16);
+}
+//Return burst mode state
+int  BurstADC::burst(void) {
+	return((adc->CR & (1 << 16)) >> 16);
+}
+
+//Set startmode and edge
+void BurstADC::startmode(int mode, int edge) {
+	int lpc_adc_temp;
+
+	//Reset start mode and edge bit,
+	lpc_adc_temp = adc->CR & ~(0x0F << 24);
+	//Write with new values
+	lpc_adc_temp |= ((mode & 7) << 24) | ((edge & 1) << 27);
+	adc->CR = lpc_adc_temp;
+}
+
+//Return startmode state according to mode_edge=0: mode and mode_edge=1: edge
+int BurstADC::startmode(int mode_edge){
+	switch (mode_edge) {
+	case 0:
+	default:
+		return((adc->CR >> 24) & 0x07);
+	case 1:
+		return((adc->CR >> 27) & 0x01);
+	}
+}
+
+//Start ADC conversion
+void BurstADC::start(void) {
+	startmode(1,0);
+}
+
+
+//Set interrupt enable/disable for pin to state
+void BurstADC::interrupt_state(PinName pin, int state) {
+	int chan;
+
+	chan = _pin_to_channel(pin);
+	if (state == 1) {
+		adc->INTEN &= ~0x100;
+		adc->INTEN |= 1 << chan;
+		/* Enable the ADC Interrupt */
+		NVIC_EnableIRQ((adc_number>0)?ADC1_IRQn:ADC0_IRQn);
+	} else {
+		adc->INTEN &= ~( 1 << chan );
+		//Disable interrrupt if no active pins left
+		if ((adc->INTEN & 0xFF) == 0)
+			NVIC_DisableIRQ((adc_number>0)?ADC1_IRQn:ADC0_IRQn);
+	}
+}
+
+//Return enable/disable state of interrupt for pin
+int BurstADC::interrupt_state(PinName pin) {
+	int chan;
+
+	chan = _pin_to_channel(pin);
+	return((adc->INTEN >> chan) & 0x01);
+}
+
+
+//Attach custom interrupt handler replacing default
+void BurstADC::attach(void(*fptr)(void)) {
+	//* Attach IRQ
+	NVIC_SetVector((adc_number>0)?ADC1_IRQn:ADC0_IRQn, (uint32_t)fptr);
+}
+
+//Restore default interrupt handler
+void BurstADC::detach(void) {
+	//* Attach IRQ
+	instance = this;
+	NVIC_SetVector((adc_number>0)?ADC1_IRQn:ADC0_IRQn, (uint32_t)&_adcisr);
+}
+
+
+//Append interrupt handler for pin to function isr
+void BurstADC::append(PinName pin, void(*fptr)(uint32_t value)) {
+	int chan;
+
+	chan = _pin_to_channel(pin);
+	_adc_isr[chan] = fptr;
+}
+
+//Append interrupt handler for pin to function isr
+void BurstADC::unappend(PinName pin) {
+	int chan;
+
+	chan = _pin_to_channel(pin);
+	_adc_isr[chan] = NULL;
+}
+
+//Unappend global interrupt handler to function isr
+void BurstADC::append(void(*fptr)(int chan, uint32_t value)) {
+	_adc_g_isr = fptr;
+}
+
+//Detach global interrupt handler to function isr
+void BurstADC::unappend() {
+	_adc_g_isr = NULL;
+}
+
+//Set ADC offset
+void BurstADC::offset(int offset) {
+	printf("Warnign no ADC Trim support");//TODO ADC Trim in LPC43xx???
+}
+
+//Return current ADC offset
+int BurstADC::offset(void) {
+	printf("Warnign no ADC Trim support");//TODO ADC Trim in LPC43xx???
+	return 0;
+}
+
+//Return value of ADC on pin
+int BurstADC::read(PinName pin) {
+	//Reset DONE and OVERRUN flags of interrupt handled ADC data
+	_adc_data[_pin_to_channel(pin)] &= ~(((uint32_t)0x01 << 31) | ((uint32_t)0x01 << 30));
+	//Return value
+	int pinData = ((_data_of_pin(pin) >> 6) & 0x3FF);
+	return pinData;
+}
+
+//Return DONE flag of ADC on pin
+int BurstADC::done(PinName pin) {
+	return((_data_of_pin(pin) >> 31) & 0x01);
+}
+
+//Return OVERRUN flag of ADC on pin
+int BurstADC::overrun(PinName pin) {
+	return((_data_of_pin(pin) >> 30) & 0x01);
+}
+
+int BurstADC::actual_adc_clock(void) {
+	return(_adc_clk_freq);
+}
+
+int BurstADC::actual_sample_rate(void) {
+	return(_adc_clk_freq / CLKS_PER_SAMPLE);
+}
+
+

--- a/src/libs/ADC/BurstADC.cpp
+++ b/src/libs/ADC/BurstADC.cpp
@@ -123,6 +123,7 @@ void BurstADC::adcisr(void)
 
 	// Read status
 	stat = adc->STAT;
+
 	//Scan channels for over-run or done and update array
 	if (stat & 0x0101) _adc_data[0] = adc->DR[0];
 	if (stat & 0x0202) _adc_data[1] = adc->DR[1];
@@ -135,11 +136,13 @@ void BurstADC::adcisr(void)
 
 	// Channel that triggered interrupt
 	chan = (adc->GDR >> 24) & 0x07;
+
 	//User defined interrupt handlers
 	if (_adc_isr[chan] != NULL)
 		_adc_isr[chan](_adc_data[chan]);
 	if (_adc_g_isr != NULL)
 		_adc_g_isr(chan, _adc_data[chan]);
+
 
 	return;
 }

--- a/src/libs/ADC/BurstADC.cpp
+++ b/src/libs/ADC/BurstADC.cpp
@@ -407,7 +407,7 @@ int BurstADC::read(PinName pin) {
 	_adc_data[_pin_to_channel(pin)] &= ~(((uint32_t)0x01 << 31) | ((uint32_t)0x01 << 30));
 	//Return value
 	int pinData = ((_data_of_pin(pin) >> 6) & 0x3FF);
-	return pinData;
+	return (pinData << 6) | ((pinData >> 4) & 0x003F); // 10 bit;
 }
 
 //Return DONE flag of ADC on pin

--- a/src/libs/ADC/BurstADC.h
+++ b/src/libs/ADC/BurstADC.h
@@ -1,0 +1,144 @@
+/*
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BURST_ADC_H
+#define BURST_ADC_H
+
+
+#include "PinNames.h"
+#include "mbed.h"
+#include "pinmap.h"
+
+#define MAX_ADC_CLOCK   4500000
+#define CLKS_PER_SAMPLE 11
+
+class BurstADC {
+public:
+
+	//Initialize ADC with ADC maximum sample rate of
+	//sample_rate and system clock divider of cclk_div
+	//Maximum recommened sample rate is .... TODO: what is the max recommended dample rate
+	BurstADC(int sample_rate, int cclk_div,int adcNumber);
+
+	//Enable/disable ADC on pin according to state
+	//and also select/de-select for next conversion
+	void setup(PinName pin, int state);
+
+	//Return enabled/disabled state of ADC on pin
+	int setup(PinName pin);
+
+	//Enable/disable burst mode according to state
+	void burst(int state);
+
+	//Select channel already setup
+	void select(PinName pin);
+
+	//Return burst mode enabled/disabled
+	int burst(void);
+
+	/*Set start condition and edge according to mode:
+	    0 - No start (this value should be used when clearing PDN to 0).
+	    1 - Start conversion now.
+	    2 - Start conversion when the edge selected by bit 27 occurs on the P2.10 / EINT0 / NMI pin.
+	    3 - Start conversion when the edge selected by bit 27 occurs on the P1.27 / CLKOUT /
+	        USB_OVRCRn / CAP0.1 pin.
+	    4 - Start conversion when the edge selected by bit 27 occurs on MAT0.1. Note that this does
+	        not require that the MAT0.1 function appear on a device pin.
+	    5 - Start conversion when the edge selected by bit 27 occurs on MAT0.3. Note that it is not
+	        possible to cause the MAT0.3 function to appear on a device pin.
+	    6 - Start conversion when the edge selected by bit 27 occurs on MAT1.0. Note that this does
+	        not require that the MAT1.0 function appear on a device pin.
+	    7 - Start conversion when the edge selected by bit 27 occurs on MAT1.1. Note that this does
+	        not require that the MAT1.1 function appear on a device pin.
+	    When mode >= 2, conversion is triggered by edge:
+	    0 - Rising edge
+	    1 - Falling edge
+	 */
+	void startmode(int mode, int edge);
+
+	//Return startmode state according to mode_edge=0: mode and mode_edge=1: edge
+	int startmode(int mode_edge);
+
+	//Start ADC conversion
+	void start(void);
+
+	//Set interrupt enable/disable for pin to state
+	void interrupt_state(PinName pin, int state);
+
+	//Return enable/disable state of interrupt for pin
+	int interrupt_state(PinName pin);
+
+	//Attach custom interrupt handler replacing default
+	void attach(void(*fptr)(void));
+
+	//Restore default interrupt handler
+	void detach(void);
+
+	//Append custom interrupt handler for pin
+	void append(PinName pin, void(*fptr)(uint32_t value));
+
+	//Unappend custom interrupt handler for pin
+	void unappend(PinName pin);
+
+	//Append custom global interrupt handler
+	void append(void(*fptr)(int chan, uint32_t value));
+
+	//Unappend custom global interrupt handler
+	void unappend(void);
+
+	//Set ADC offset to a value 0-7
+	void offset(int offset);
+
+	//Return current ADC offset
+	int offset(void);
+
+	//Return value of ADC on pin
+	int read(PinName pin);
+
+	//Return DONE flag of ADC on pin
+	int done(PinName pin);
+
+	//Return OVERRUN flag of ADC on pin
+	int overrun(PinName pin);
+
+	//Return actual ADC clock
+	int actual_adc_clock(void);
+
+	//Return actual maximum sample rate
+	int actual_sample_rate(void);
+
+	//Return pin ID of ADC channel
+	PinName channel_to_pin(int chan);
+
+	//Return pin number of ADC channel
+	int channel_to_pin_number(int chan);
+
+	int _pin_to_channel(PinName pin);
+
+
+private:
+
+
+	uint32_t _data_of_pin(PinName pin);
+
+	int _adc_clk_freq;
+	void adcisr(void);
+	static void _adcisr(void);
+	static BurstADC *instance;
+
+	LPC_ADC_T *adc;
+	int adc_number;
+
+	uint32_t _adc_data[8];
+	void(*_adc_isr[8])(uint32_t value);
+	void(*_adc_g_isr)(int chan, uint32_t value);
+	void(*_adc_m_isr)(void);
+
+};
+
+
+#endif

--- a/src/libs/Adc.cpp
+++ b/src/libs/Adc.cpp
@@ -3,60 +3,73 @@
       Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
       Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
       You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
-*/
+ */
 
 #include "Adc.h"
 #include "libs/nuts_bolts.h"
 #include "libs/Kernel.h"
 #include "libs/Pin.h"
-// TOADDBACK#include "libs/ADC/adc.h"
+#include "libs/ADC/BurstADC.h"
 #include "libs/Pin.h"
 
 
 using namespace std;
 #include <vector>
-// This is an interface to the mbed.org ADC library you can find in libs/ADC/adc.h
-// TODO : Having the same name is confusing, should change that
+
+Adc *Adc::instance;
+
+static void sample_isr(int chan, uint32_t value)
+{
+	Adc::instance->new_sample(chan, value);
+}
 
 Adc::Adc(){
-    //this->analogin = new AnalogIn(P4_3);
-    // TOADDBACK this->adc = new ADC(1000, 1);
+	instance = this;
+	// ADC sample rate need to be fast enough to be able to read the enabled channels within the thermistor poll time
+	// even though ther maybe 32 samples we only need one new one within the polling time
+
+
+	const uint32_t sample_rate= 400000; // 400KHz sample rate
+	this->adc = new BurstADC(sample_rate, 8, 0);
+	this->adc->append(sample_isr);
+}
+
+// Keeps the last 8 values for each channel
+// This is called in an ISR, so sample_buffers needs to be accessed atomically
+void Adc::new_sample(int chan, uint32_t value)
+{
+	// Shuffle down and add new value to the end
+	if(chan < num_channels) {
+		memmove(&sample_buffers[chan][0], &sample_buffers[chan][1], sizeof(sample_buffers[0]) - sizeof(sample_buffers[0][0]));
+		//sample_buffers[chan][num_samples - 1] = (value >> 4) & 0xFFF; // the 12 bit ADC reading
+		sample_buffers[chan][num_samples - 1] = (value >> 6) & 0x3FF; // the 10 bit ADC reading
+	}
 }
 
 // Enables ADC on a given pin
 void Adc::enable_pin(Pin* pin){
+	/*
+			 PinName pin_name = this->_pin_to_pinname(pin);
+			this->analogin = new AnalogIn(pin_name);
+	 */
+
 	PinName pin_name = this->_pin_to_pinname(pin);
-	this->analogin = new AnalogIn(pin_name);
-    /* TOADDBACK PinName pin_name = this->_pin_to_pinname(pin);
-    this->adc->burst(1);
-    this->adc->setup(pin_name,1);
-    this->adc->interrupt_state(pin_name,1); */
+	int channel = adc->_pin_to_channel(pin_name);
+	memset(sample_buffers[channel], 0, sizeof(sample_buffers[0]));
+
+	this->adc->burst(1);
+	this->adc->setup(pin_name, 1);
+	this->adc->interrupt_state(pin_name, 0);
 }
 
 // Read the last value ( burst mode ) on a given pin
 unsigned int Adc::read(Pin* pin){
-    // TOADDBACK return this->adc->read(this->_pin_to_pinname(pin));
-    return this->analogin->read_u16();
+	return this->adc->read(this->_pin_to_pinname(pin));
 }
 
 // Convert a smoothie Pin into a mBed Pin
 PinName Adc::_pin_to_pinname(Pin* pin){
 	return pin->getPinName();
-    /* TOADDBACK if( pin->port == LPC_GPIO0 && pin->pin == 23 ){
-        return p15;
-    }else if( pin->port == LPC_GPIO0 && pin->pin == 24 ){
-        return p16;
-    }else if( pin->port == LPC_GPIO0 && pin->pin == 25 ){
-        return p17;
-    }else if( pin->port == LPC_GPIO0 && pin->pin == 26 ){
-        return p18;
-    }else if( pin->port == LPC_GPIO1 && pin->pin == 30 ){
-        return p19;
-    }else if( pin->port == LPC_GPIO1 && pin->pin == 31 ){
-        return p20;
-    }else{
-        //TODO: Error
-        return NC;
-    } */
+
 }
 

--- a/src/libs/Adc.cpp
+++ b/src/libs/Adc.cpp
@@ -59,7 +59,7 @@ void Adc::enable_pin(Pin* pin){
 
 	this->adc->burst(1);
 	this->adc->setup(pin_name, 1);
-	this->adc->interrupt_state(pin_name, 0);
+	this->adc->interrupt_state(pin_name, 0);//TODO interrupt p
 }
 
 // Read the last value ( burst mode ) on a given pin

--- a/src/libs/Adc.cpp
+++ b/src/libs/Adc.cpp
@@ -59,7 +59,7 @@ void Adc::enable_pin(Pin* pin){
 
 	this->adc->burst(1);
 	this->adc->setup(pin_name, 1);
-	this->adc->interrupt_state(pin_name, 0);//TODO interrupt p
+	this->adc->interrupt_state(pin_name, 0);//TODO Find out what is wrong with interrupts
 }
 
 // Read the last value ( burst mode ) on a given pin

--- a/src/libs/Adc.cpp
+++ b/src/libs/Adc.cpp
@@ -62,14 +62,14 @@ void Adc::enable_pin(Pin* pin){
 	this->adc->interrupt_state(pin_name, 0);//TODO Find out what is wrong with interrupts
 }
 
-
+/*
 // Read the last value ( burst mode ) on a given pin
 unsigned int Adc::read(Pin* pin){
 	return this->adc->read(this->_pin_to_pinname(pin));
 }
+*/
 
 
-/*
 //#define USE_MEDIAN_FILTER
 // Read the filtered value ( burst mode ) on a given pin
 unsigned int Adc::read(Pin *pin)
@@ -104,7 +104,7 @@ unsigned int Adc::read(Pin *pin)
 	ave_buf[channel][3]= ave_buf[channel][2];
 	ave_buf[channel][2]= ave_buf[channel][1];
 	ave_buf[channel][1]= ave_buf[channel][0];
-	ave_buf[channel][0]= sum >> OVERSAMPLE*2;
+	ave_buf[channel][0]= sum >> OVERSAMPLE;
 
 	unsigned int tValue =roundf((ave_buf[channel][0]+ave_buf[channel][1]+ave_buf[channel][2]+ave_buf[channel][3])/4.0F);
 
@@ -121,7 +121,7 @@ unsigned int Adc::read(Pin *pin)
 
 #endif
 }
-*/
+
 
 // Convert a smoothie Pin into a mBed Pin
 PinName Adc::_pin_to_pinname(Pin* pin){

--- a/src/libs/Adc.cpp
+++ b/src/libs/Adc.cpp
@@ -19,12 +19,14 @@ using namespace std;
 // TODO : Having the same name is confusing, should change that
 
 Adc::Adc(){
-    this->analogin = new AnalogIn(P4_3);
+    //this->analogin = new AnalogIn(P4_3);
     // TOADDBACK this->adc = new ADC(1000, 1);
 }
 
 // Enables ADC on a given pin
 void Adc::enable_pin(Pin* pin){
+	PinName pin_name = this->_pin_to_pinname(pin);
+	this->analogin = new AnalogIn(pin_name);
     /* TOADDBACK PinName pin_name = this->_pin_to_pinname(pin);
     this->adc->burst(1);
     this->adc->setup(pin_name,1);
@@ -39,6 +41,7 @@ unsigned int Adc::read(Pin* pin){
 
 // Convert a smoothie Pin into a mBed Pin
 PinName Adc::_pin_to_pinname(Pin* pin){
+	return pin->getPinName();
     /* TOADDBACK if( pin->port == LPC_GPIO0 && pin->pin == 23 ){
         return p15;
     }else if( pin->port == LPC_GPIO0 && pin->pin == 24 ){

--- a/src/libs/Adc.h
+++ b/src/libs/Adc.h
@@ -3,7 +3,7 @@
       Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
       Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
       You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
-*/
+ */
 
 
 
@@ -12,21 +12,47 @@
 
 #include "PinNames.h" // mbed.h lib
 #include "mbed.h"
-// TOADDBACK #include "libs/ADC/adc.h"
+#include "libs/ADC/BurstADC.h"
+
+#include <cmath>
+#include <algorithm>
 
 class Pin;
 
 class Adc {
-    public:
-        Adc();
-        void enable_pin(Pin* pin);
-        unsigned int read(Pin* pin);
-        PinName _pin_to_pinname(Pin* pin);
+public:
+	Adc();
+	void enable_pin(Pin* pin);
+	unsigned int read(Pin* pin);
 
-        AnalogIn* analogin;
-        // TOADDBACK ADC* adc;
+	static Adc *instance;
 
-        int get_max_value() const { return 65536;}    //Assuming 16bit reading from mbed
+	//AnalogIn* analogin;		//TODO remove
+
+	void new_sample(int chan, uint32_t value);
+	// return the maximum ADC value, base is 12bits 4095.
+#ifdef OVERSAMPLE
+	int get_max_value() const { return 4095 << OVERSAMPLE;}
+#else
+	int get_max_value() const { return 65536;}    //Assuming 16bit reading from mbed
+	//int get_max_value() const { return 4294967296;}    //Assuming 32bit reading from mbed
+#endif
+
+private:
+	PinName _pin_to_pinname(Pin *pin);
+	BurstADC* adc;
+
+	static const int num_channels= 8;
+#ifdef OVERSAMPLE
+	// we need 4^n sample to oversample and we get double that to filter out spikes
+	static const int num_samples= powf(4, OVERSAMPLE)*2;
+#else
+	static const int num_samples= 8;
+#endif
+
+	// buffers storing the last num_samples readings for each channel
+	uint16_t sample_buffers[num_channels][num_samples];
+
 };
 
 

--- a/src/libs/Adc.h
+++ b/src/libs/Adc.h
@@ -25,6 +25,8 @@ class Adc {
 
         AnalogIn* analogin;
         // TOADDBACK ADC* adc;
+
+        int get_max_value() const { return 65536;}    //Assuming 16bit reading from mbed
 };
 
 

--- a/src/libs/Adc.h
+++ b/src/libs/Adc.h
@@ -35,7 +35,7 @@ public:
 	void new_sample(int chan, uint32_t value);
 	// return the maximum ADC value, base is 12bits 4095.
 #ifdef OVERSAMPLE
-	int get_max_value() const { return 65535 << OVERSAMPLE;}
+	int get_max_value() const { return 1025 << OVERSAMPLE;}
 #else
 	int get_max_value() const { return 65535;}    //Assuming 16bit reading from mbed
 	//int get_max_value() const { return 4294967296;}    //Assuming 32bit reading from mbed

--- a/src/libs/Adc.h
+++ b/src/libs/Adc.h
@@ -19,6 +19,9 @@
 
 class Pin;
 
+// 2 bits means the 10bit ADC is 12 bits of resolution
+#define OVERSAMPLE 2
+
 class Adc {
 public:
 	Adc();
@@ -32,9 +35,9 @@ public:
 	void new_sample(int chan, uint32_t value);
 	// return the maximum ADC value, base is 12bits 4095.
 #ifdef OVERSAMPLE
-	int get_max_value() const { return 4095 << OVERSAMPLE;}
+	int get_max_value() const { return 65535 << OVERSAMPLE;}
 #else
-	int get_max_value() const { return 65536;}    //Assuming 16bit reading from mbed
+	int get_max_value() const { return 65535;}    //Assuming 16bit reading from mbed
 	//int get_max_value() const { return 4294967296;}    //Assuming 32bit reading from mbed
 #endif
 

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -10,7 +10,7 @@
 #include "libs/Config.h"
 #include "libs/nuts_bolts.h"
 #include "libs/SlowTicker.h"
-//#include "libs/Adc.h"
+#include "libs/Adc.h"
 #include "libs/StreamOutputPool.h"
 //#include <mri.h>
 #include "checksumm.h"
@@ -75,7 +75,7 @@ Kernel::Kernel(){
     this->config->config_cache_load();
 
     // ADC reading
-    //this->adc = new Adc();
+    this->adc = new Adc();
 
     // For slow repeteative tasks
     this->add_module( this->slow_ticker = new SlowTicker());

--- a/src/libs/Pin.cpp
+++ b/src/libs/Pin.cpp
@@ -28,10 +28,32 @@ Pin* Pin::from_string(std::string value){
     char* cn = NULL;
     valid= true;
 
+    //initialize adc only vars
+    adc_only = false;
+    adc_channel = 0xff;
+
+    //verify if it is an analog only pin
+    std::size_t found = value.find("adc");
+    if (found!=std::string::npos) adc_only = true;
+
+    if(adc_only)
+    {
+    	std::string channelStr = value.substr (4);
+    	cs = channelStr.c_str();
+    	adc_channel = strtol(cs, &cn, 10);
+
+    	PinName adc_pins[16] = {adc0_0,adc0_1,adc0_2,adc0_3,adc0_4,adc0_5,adc0_6,adc0_7,adc1_0,adc1_1,adc1_2,adc1_3,adc1_4,adc1_5,adc1_6,adc1_7};
+    	this->pinName = adc_pins[adc_channel];
+
+    	return this;
+    }
+
+
     // grab first integer as port. pointer to first non-digit goes in cn
-    port_number = strtol(cs, &cn, 10);
+    port_number = strtol(cs, &cn, 16); //allow hexadecimal portnumbes
+
     // if cn > cs then strtol read at least one digit
-    if ((cn > cs) && (port_number <= 7)){
+    if ((cn > cs) && (port_number <= 15)){
         // if the char after the first integer is a . then we should expect a pin index next
         if (*cn == '.'){
             // move pointer to first digit (hopefully) of pin index
@@ -45,6 +67,7 @@ Pin* Pin::from_string(std::string value){
             // Find the pin
             if( pins.count((port_number<<8)+pin) > 0 ){
                 this->mbed_pin = new DigitalInOut( pins[(port_number<<8)+pin] );
+                this->pinName = pins[(port_number<<8)+pin];
             }
 
             // if strtol read some numbers, cn will point to the first non-digit

--- a/src/libs/Pin.h
+++ b/src/libs/Pin.h
@@ -9,78 +9,87 @@
 #include "PinNames.h"
 
 namespace mbed {
-    class PwmOut;
-    class InterruptIn;
+class PwmOut;
+class InterruptIn;
 }
 
 #include "mbed.h"
 
 class Pin {
-    public:
-        Pin();
+public:
+	Pin();
 
-        Pin* from_string(std::string value);
+	Pin* from_string(std::string value);
 
-        inline bool connected(){
-            return this->valid;
-        }
+	inline bool connected(){
+		return this->valid;
+	}
 
-        inline bool equals(const Pin& other) const {
-            //return (this->pin == other.pin) && (this->port == other.port);
-            return false;
-        }
+	inline bool equals(const Pin& other) const {
+		//return (this->pin == other.pin) && (this->port == other.port);
+		return false;
+	}
 
-        inline Pin* as_output(){
-            if (this->valid)
-                this->mbed_pin->output(); 
-            return this;
-        }
+	inline Pin* as_output(){
+		if (this->valid)
+			this->mbed_pin->output();
+		return this;
+	}
 
-        inline Pin* as_input(){
-            if (this->valid)
-                this->mbed_pin->input();
-            return this;
-        }
+	inline Pin* as_input(){
+		if (this->valid)
+			this->mbed_pin->input();
+		return this;
+	}
 
-        Pin* as_open_drain(void);
+	Pin* as_open_drain(void);
 
-        Pin* as_repeater(void);
+	Pin* as_repeater(void);
 
-        Pin* pull_up(void);
+	Pin* pull_up(void);
 
-        Pin* pull_down(void);
+	Pin* pull_down(void);
 
-        Pin* pull_none(void);
+	Pin* pull_none(void);
 
-        inline bool get(){
-            if (!this->valid) return false;
-            return this->inverting ^ ( (bool)this->mbed_pin->read() );
-        }
+	inline bool get(){
+		if (!this->valid) return false;
+		return this->inverting ^ ( (bool)this->mbed_pin->read() );
+	}
 
-        inline void set(bool value)
-        {
-            if (!this->valid) return;
-            if ( this->inverting ^ value ){
-                this->mbed_pin->write(1);
-            }else{
-                this->mbed_pin->write(0);
-            }
-        }
+	inline void set(bool value)
+	{
+		if (!this->valid) return;
+		if ( this->inverting ^ value ){
+			this->mbed_pin->write(1);
+		}else{
+			this->mbed_pin->write(0);
+		}
+	}
 
-        mbed::PwmOut *hardware_pwm();
+	mbed::PwmOut *hardware_pwm();
 
-        mbed::InterruptIn *interrupt_pin();
+	mbed::InterruptIn *interrupt_pin();
 
-        bool is_inverting() const { return inverting; }
-        void set_inverting(bool f) { inverting= f; }
+	bool is_inverting() const { return inverting; }
+	void set_inverting(bool f) { inverting= f; }
 
-        // these should be private, and use getters
-        DigitalInOut* mbed_pin;
+	// these should be private, and use getters
+	DigitalInOut* mbed_pin;
 
-        struct {
-            bool inverting:1;
-            bool valid:1;
-        };
+	struct {
+		bool inverting:1;
+		bool valid:1;
+		bool adc_only:1;    //true if adc only pin
+		int adc_channel:8;    //adc channel
+	};
+
+	//getter to access to mbed pinName
+	PinName getPinName() {return pinName; }
+
+private:
+	//Added pinName
+	PinName pinName;
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 /* Test which brings default HelloWorld project from mbed online compiler
    to be built under GCC.
-*/
+ */
 #include "mbed.h"
 #include "Kernel.h"
 #include "SwitchPool.h"
@@ -10,36 +10,48 @@
 #include "Config.h"
 #include "StreamOutputPool.h"
 
+DigitalOut leds[4] = {
+		DigitalOut(LED1),
+		DigitalOut(LED2),
+		DigitalOut(LED3),
+		DigitalOut(LED4)
+};
+
 int main() {
 
-    // Kernel creates modules, and receives and dispatches events between them
-    Kernel* kernel = new Kernel();
+	int cnt = 0;
 
-    // Say hello ( TODO : Add back version and all )
-    kernel->streams->printf("Smoothie2 dev\n");
+	// Kernel creates modules, and receives and dispatches events between them
+	Kernel* kernel = new Kernel();
 
-    // Create and add main modules
-    kernel->add_module( new Endstops() );
-    kernel->add_module( new Laser() );
+	// Say hello ( TODO : Add back version and all )
+	kernel->streams->printf("Smoothie2 dev\n");
 
-    // Create all Switch modules
-    SwitchPool *sp= new SwitchPool();
-    sp->load_tools();
-    delete sp;
+	// Create and add main modules
+	kernel->add_module( new Endstops() );
+	kernel->add_module( new Laser() );
 
-    // TOADDBACK 
-    // Create all TemperatureControl modules. Note order is important here must be after extruder so Tn as a parameter will get executed first
-    // TemperatureControlPool *tp= new TemperatureControlPool();
-    // tp->load_tools();
-    // delete tp;
+	// Create all Switch modules
+	SwitchPool *sp= new SwitchPool();
+	sp->load_tools();
+	delete sp;
 
-    // Clear the configuration cache as it is no longer needed
-    kernel->config->config_cache_clear();
+	// Create all TemperatureControl modules. Note order is important here must be after extruder so Tn as a parameter will get executed first
+	TemperatureControlPool *tp= new TemperatureControlPool();
+	tp->load_tools();
+	delete tp;
 
-    // Main loop
-    while(1){
-        THEKERNEL->call_event(ON_MAIN_LOOP);
-        THEKERNEL->call_event(ON_IDLE);
-    }
+	// Clear the configuration cache as it is no longer needed
+	kernel->config->config_cache_clear();
+
+	// Main loop
+	while(1){
+		if(THEKERNEL->is_using_leds()) {
+			// flash led 2 to show we are alive
+			leds[0]= (cnt++ & 0x1000) ? 1 : 0;
+		}
+		THEKERNEL->call_event(ON_MAIN_LOOP);
+		THEKERNEL->call_event(ON_IDLE);
+	}
 
 }

--- a/src/makefile
+++ b/src/makefile
@@ -2,7 +2,7 @@
 # Can be one of: Smoothie2Proto1 (**current default**)
 #                Bambino210E
 #                Bambino200E
-BOARD ?= Smoothie2Proto1
+BOARD ?= Bambino210E
 
 # Set MRI_ENABLE to a value of 1 to enable the MRI debug monitor on the secondary UART.
 MRI_ENABLE ?= 0
@@ -13,7 +13,7 @@ MRI_BREAK_ON_INIT ?= 1
 # Can set OPTIMIZATION to 0 to disable compiler optimizations. This makes debugging easier but the code will run more
 # slowly. It may run so slowly that it fails to execute properly since some routines (ie. step tickers) are
 # time sensitive.
-# OPTIMIZATION        :=  0
+OPTIMIZATION        :=  0
 
 
 

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -128,7 +128,7 @@ void TemperatureControl::load_config()
     this->set_m_code          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, set_m_code_checksum)->by_default(104)->as_number();
     this->set_and_wait_m_code = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, set_and_wait_m_code_checksum)->by_default(109)->as_number();
     this->get_m_code          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, get_m_code_checksum)->by_default(105)->as_number();
-    this->readings_per_second = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, readings_per_second_checksum)->by_default(20)->as_number();
+    this->readings_per_second = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, readings_per_second_checksum)->by_default(160)->as_number();
 
     this->designator          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, designator_checksum)->by_default(string("T"))->as_string();
 

--- a/src/modules/tools/temperaturecontrol/Thermistor.cpp
+++ b/src/modules/tools/temperaturecontrol/Thermistor.cpp
@@ -124,7 +124,7 @@ void Thermistor::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
 
     // Thermistor pin for ADC readings
     this->thermistor_pin.from_string(THEKERNEL->config->value(module_checksum, name_checksum, thermistor_pin_checksum )->required()->as_string());
-    // TOADDBACK THEKERNEL->adc->enable_pin(&thermistor_pin);
+    THEKERNEL->adc->enable_pin(&thermistor_pin);
 
     // specify the three Steinhart-Hart coefficients
     // specified as three comma separated floats, no spaces
@@ -251,7 +251,7 @@ void Thermistor::get_raw()
     }
 
     int adc_value= new_thermistor_reading();
-    const uint32_t max_adc_value= 0; // TOADDBACK THEKERNEL->adc->get_max_value();
+    const uint32_t max_adc_value= THEKERNEL->adc->get_max_value();
 
      // resistance of the thermistor in ohms
     float r = r2 / (((float)max_adc_value / adc_value) - 1.0F);
@@ -282,7 +282,7 @@ void Thermistor::get_raw()
 
 float Thermistor::adc_value_to_temperature(uint32_t adc_value)
 {
-    const uint32_t max_adc_value= 0; //TOADDBACK THEKERNEL->adc->get_max_value();
+    const uint32_t max_adc_value= THEKERNEL->adc->get_max_value();
     if ((adc_value >= max_adc_value) || (adc_value == 0))
         return infinityf();
 


### PR DESCRIPTION
The current push request includes changes to configure the ADC in Burst mode. This implementation followed the "libs/ADC/adc" implementation from smoothie v1.

Currently known limitations and TODOS:
- When ADC channel interrupt are enabled, ADC ISR is not clearing the interrupt flag blocking code execution (NEED help with this);
- After solving the interrupt problem it is necessary to iplement Median Fitler and oversampling.
