### PR TITLE
Step generation using chip Timers

### DIFF
--- a/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
+++ b/gcc4mbed/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
@@ -73,18 +73,14 @@ void analogin_init(analogin_t *obj, PinName pin) {
 	MBED_ASSERT(obj->adc != (LPC_ADC_T *)NC);
 
 	// Set ADC number
-	if(name < ADC1_0)
-	{
-		obj->num = 0;
-	} else if(name < ADC_pin0_0 && name > ADC0_6)
-	{
-		obj->num = 1;
-	} else if(name < ADC_pin1_1 && name > ADC1_7)
-	{
-		obj->num = 0;
-	} else if(name > ADC_pin0_7)
-	{
-		obj->num = 1;
+    if(name < ADC1_0) {
+        obj->num = 0;
+	} else if(name < ADC_pin0_0 && name > ADC0_6) {
+        obj->num = 1;
+	} else if(name < ADC_pin1_1 && name > ADC1_7) {
+        obj->num = 0;
+	} else if(name > ADC_pin0_7) {
+        obj->num = 1;
 	}
 
 	//ADC register and channel
@@ -92,8 +88,7 @@ void analogin_init(analogin_t *obj, PinName pin) {
 	obj->adc = (LPC_ADC_T *) (obj->num > 0) ? LPC_ADC1 : LPC_ADC0;
 
 	// Reset pin function to GPIO if it is a GPIO pin. for adc only pins it is not necessary
-	if(name < ADC_pin0_0)
-	{
+	if(name < ADC_pin0_0) {
 		gpio_set(pin);
 		// Select ADC on analog function select register in SCU
 		LPC_SCU->ENAIO[obj->num] |= (1 << obj->ch);

--- a/src/config.default
+++ b/src/config.default
@@ -1,31 +1,140 @@
-# this file is proprietary. do not distribute.
-# Switch module for fan control
-switch.first.enable                            true             #
-switch.first.input_on_command                  M106             #
-switch.first.input_off_command                 M107             #
-switch.first.output_pin                        2.8              #
-switch.first.output_type                       digital          # pwm output settable with S parameter in the input_on_comand
+# NOTE Lines must not exceed 132 characters
+## Robot module configurations : general handling of movement G-codes and slicing into moves
+default_feed_rate                            4000             # Default rate ( mm/minute ) for G1/G2/G3 moves
+default_seek_rate                            4000             # Default rate ( mm/minute ) for G0 moves
+mm_per_arc_segment                           0.0              # Fixed length for line segments that divide arcs 0 to disable
+mm_max_arc_error                             0.01             # The maximum error for line segments that divide arcs 0 to disable
+                                                              # note it is invalid for both the above be 0
+                                                              # if both are used, will use largest segment length based on radius
+#mm_per_line_segment                          5                # Lines can be cut into segments ( not usefull with cartesian
+                                                              # coordinates robots ).
 
-switch.second.enable                            true             #
-switch.second.input_on_command                  M116             #
-switch.second.input_off_command                 M117             #
-switch.second.output_pin                        2.9              #
-switch.second.output_type                       pwm             # pwm output settable with S parameter in the input_on_comand
+# Arm solution configuration : Cartesian robot. Translates mm positions into stepper positions
+alpha_steps_per_mm                           80               # Steps per mm for alpha stepper
+beta_steps_per_mm                            80               # Steps per mm for beta stepper
+gamma_steps_per_mm                           1600             # Steps per mm for gamma stepper
 
-microseconds_per_step_pulse                     5
+# Planner module configuration : Look-ahead and acceleration configuration
+planner_queue_size                           32               # DO NOT CHANGE THIS UNLESS YOU KNOW EXACTLY WHAT YOU ARE DOING
+acceleration                                 3000             # Acceleration in mm/second/second.
+#z_acceleration                              500              # Acceleration for Z only moves in mm/s^2, 0 uses acceleration which is the default. DO NOT SET ON A DELTA
+acceleration_ticks_per_second                1000             # Number of times per second the speed is updated
+junction_deviation                           0.05             # Similar to the old "max_jerk", in millimeters,
+                                                              # see https://github.com/grbl/grbl/blob/master/planner.c
+                                                              # and https://github.com/grbl/grbl/wiki/Configuring-Grbl-v0.8
+                                                              # Lower values mean being more careful, higher values means being
+                                                              # faster and have more jerk
+#z_junction_deviation                        0.0              # for Z only moves, -1 uses junction_deviation, zero disables junction_deviation on z moves DO NOT SET ON A DELTA
+#minimum_planner_speed                       0.0              # sets the minimum planner speed in mm/sec
 
-alpha_step_pin    1.7
-beta_step_pin     1.8
+# Stepper module configuration
+microseconds_per_step_pulse                  2                # Duration of step pulses to stepper drivers, in microseconds
+base_stepping_frequency                      1000           # Base frequency for stepping
+
+# Cartesian axis speed limits
+x_axis_max_speed                             30000            # mm/min
+y_axis_max_speed                             30000            # mm/min
+z_axis_max_speed                             300              # mm/min
+
+# Stepper module pins ( ports, and pin numbers, appending "!" to the number will invert a pin )
+alpha_step_pin                               3.2              # Pin for alpha stepper step signal
+alpha_dir_pin                                7.3              # Pin for alpha stepper direction
+alpha_en_pin                                 7.2              # Pin for alpha enable pin
+alpha_current                                1.5              # X stepper motor current
+alpha_max_rate                               30000.0          # mm/min
+
+beta_step_pin                                4.2              # Pin for beta stepper step signal
+beta_dir_pin                                 7.0              # Pin for beta stepper direction
+beta_en_pin                                  4.5              # Pin for beta enable
+beta_current                                 1.5              # Y stepper motor current
+beta_max_rate                                30000.0          # mm/min
+
+gamma_step_pin                               5.7              # Pin for gamma stepper step signal
+gamma_dir_pin                                5.5              # Pin for gamma stepper direction
+gamma_en_pin                                 7.6              # Pin for gamma enable
+gamma_current                                1.5              # Z stepper motor current
+gamma_max_rate                               300.0            # mm/min
+
+## System configuration
+# Serial communications configuration ( baud rate defaults to 9600 if undefined )
+uart0.baud_rate                              115200           # Baud rate for the default hardware serial port
+second_usb_serial_enable                     false            # This enables a second usb serial port (to have both pronterface
+                                                              # and a terminal connected)
+#leds_disable                                true             # disable using leds after config loaded
+#play_led_disable                            true             # disable the play led
+
+# Kill button (used to be called pause) maybe assigned to a different pin, set to the onboard pin by default
+kill_button_enable                           false             # set to true to enable a kill button
+kill_button_pin                              2.12             # kill button pin. default is same as pause button 2.12 (2.11 is another good choice)
+
+#msd_disable                                 false            # disable the MSD (USB SDCARD) when set to true (needs special binary)
+#dfu_enable                                  false            # for linux developers, set to true to enable DFU
+#watchdog_timeout                            10               # watchdog timeout in seconds, default is 10, set to 0 to disable the watchdog
+
+# Only needed on a smoothieboard
+currentcontrol_module_enable                 false             #
+
+## Extruder module configuration
+extruder.hotend.enable                          true             # Whether to activate the extruder module at all. All configuration is ignored if false
+extruder.hotend.steps_per_mm                    140              # Steps per mm for extruder stepper
+extruder.hotend.default_feed_rate               600              # Default rate ( mm/minute ) for moves where only the extruder moves
+extruder.hotend.acceleration                    500              # Acceleration for the stepper motor mm/sec²
+extruder.hotend.max_speed                       50               # mm/s
+
+extruder.hotend.step_pin                        6.4              # Pin for extruder step signal
+extruder.hotend.dir_pin                         6.5              # Pin for extruder dir signal
+extruder.hotend.en_pin                          1.7              # Pin for extruder enable signal
+
+# extruder offset
+#extruder.hotend.x_offset                        0                # x offset from origin in mm
+#extruder.hotend.y_offset                        0                # y offset from origin in mm
+#extruder.hotend.z_offset                        0                # z offset from origin in mm
+
+# firmware retract settings when using G10/G11, these are the defaults if not defined, must be defined for each extruder if not using the defaults
+#extruder.hotend.retract_length                  3               # retract length in mm
+#extruder.hotend.retract_feedrate                45              # retract feedrate in mm/sec
+#extruder.hotend.retract_recover_length          0               # additional length for recover
+#extruder.hotend.retract_recover_feedrate        8               # recover feedrate in mm/sec (should be less than retract feedrate)
+#extruder.hotend.retract_zlift_length            0               # zlift on retract in mm, 0 disables
+#extruder.hotend.retract_zlift_feedrate          6000            # zlift feedrate in mm/min (Note mm/min NOT mm/sec)
+
+delta_current                                1.5              # First extruder stepper motor current
+
+# Second extruder module configuration
+#extruder.hotend2.enable                          true             # Whether to activate the extruder module at all. All configuration is ignored if false
+#extruder.hotend2.steps_per_mm                    140              # Steps per mm for extruder stepper
+#extruder.hotend2.default_feed_rate               600              # Default rate ( mm/minute ) for moves where only the extruder moves
+#extruder.hotend2.acceleration                    500              # Acceleration for the stepper motor, as of 0.6, arbitrary ratio
+#extruder.hotend2.max_speed                       50               # mm/s
+
+#extruder.hotend2.step_pin                        6.10             # Pin for extruder step signal
+#extruder.hotend2.dir_pin                         2.9              # Pin for extruder dir signal
+#extruder.hotend2.en_pin                          2.8              # Pin for extruder enable signal
+
+#extruder.hotend2.x_offset                        0                # x offset from origin in mm
+#extruder.hotend2.y_offset                        25.0             # y offset from origin in mm
+#extruder.hotend2.z_offset                        0                # z offset from origin in mm
+#epsilon_current                              1.5              # Second extruder stepper motor current
 
 
-junction_deviation 0.05
-acceleration 100
+## Laser module configuration
+laser_module_enable                          false            # Whether to activate the laser module at all. All configuration is
+                                                              # ignored if false.
+#laser_module_pin                             2.5             # this pin will be PWMed to control the laser. Only P2.0 - P2.5, P1.18, P1.20, P1.21, P1.23, P1.24, P1.26, P3.25, P3.26
+                                                              # can be used since laser requires hardware PWM
+#laser_module_maximum_power                   1.0             # this is the maximum duty cycle that will be applied to the laser
+#laser_module_minimum_power                   0.0             # This is a value just below the minimum duty cycle that keeps the laser
+                                                              # active without actually burning.
+#laser_module_default_power                   0.8             # This is the default laser power that will be used for cuts if a power has not been specified.  The value is a scale between
+                                                              # the maximum and minimum power levels specified above
+#laser_module_pwm_period                      20              # this sets the pwm frequency as the period in microseconds
 
-# Hotend temperature control configuration
+## Temperature control configuration
+# First hotend configuration
 temperature_control.hotend.enable            true             # Whether to activate this ( "hotend" ) module at all.
                                                               # All configuration is ignored if false.
 temperature_control.hotend.thermistor_pin    adc.5             # Pin for the thermistor to read
-temperature_control.hotend.heater_pin        2.7              # Pin that controls the heater, set to nc if a readonly thermistor is being defined
+temperature_control.hotend.heater_pin        7.5              # Pin that controls the heater, set to nc if a readonly thermistor is being defined
 temperature_control.hotend.thermistor        EPCOS100K        # see http://smoothieware.org/temperaturecontrol#toc5
 #temperature_control.hotend.beta             4066             # or set the beta value
 temperature_control.hotend.set_m_code        104              #
@@ -40,3 +149,174 @@ temperature_control.hotend.designator        T                #
 
 #temperature_control.hotend.max_pwm          64               # max pwm, 64 is a good value if driving a 12v resistor with 24v.
 
+# Second hotend configuration
+temperature_control.hotend2.enable            true             # Whether to activate this ( "hotend" ) module at all.
+                                                              # All configuration is ignored if false.
+
+temperature_control.hotend2.thermistor_pin    adc.7             # Pin for the thermistor to read
+temperature_control.hotend2.heater_pin        7.7              # Pin that controls the heater
+temperature_control.hotend2.thermistor        EPCOS100K        # see http://smoothieware.org/temperaturecontrol#toc5
+#temperature_control.hotend2.beta             4066             # or set the beta value
+temperature_control.hotend2.set_m_code        104              #
+temperature_control.hotend2.set_and_wait_m_code 109            #
+temperature_control.hotend2.designator        T1               #
+
+#temperature_control.hotend2.p_factor          13.7           # permanently set the PID values after an auto pid
+#temperature_control.hotend2.i_factor          0.097          #
+#temperature_control.hotend2.d_factor          24             #
+
+#temperature_control.hotend2.max_pwm          64               # max pwm, 64 is a good value if driving a 12v resistor with 24v.
+
+temperature_control.bed.enable               false             #
+temperature_control.bed.thermistor_pin       adc.2             #
+temperature_control.bed.heater_pin           7.7              #
+temperature_control.bed.thermistor           Honeywell100K    # see http://smoothieware.org/temperaturecontrol#toc5
+#temperature_control.bed.beta                3974             # or set the beta value
+
+temperature_control.bed.set_m_code           140              #
+temperature_control.bed.set_and_wait_m_code  190              #
+temperature_control.bed.designator           B                #
+
+#temperature_control.bed.bang_bang            false           # set to true to use bang bang control rather than PID
+#temperature_control.bed.hysteresis           2.0             # set to the temperature in degrees C to use as hysteresis
+                                                              # when using bang bang
+
+## Switch module for fan control
+switch.fan.enable                            true             #
+switch.fan.input_on_command                  M106             #
+switch.fan.input_off_command                 M107             #
+switch.fan.output_pin                        4.1              #
+switch.fan.output_type                       pwm              # pwm output settable with S parameter in the input_on_comand
+#switch.fan.max_pwm                           255              # set max pwm for the pin default is 255
+
+#switch.misc.enable                           true             #
+#switch.misc.input_on_command                 M42              #
+#switch.misc.input_off_command                M43              #
+#switch.misc.output_pin                       2.4              #
+#switch.misc.output_type                      digital          # just an on or off pin
+
+# Switch module for spindle control
+#switch.spindle.enable                        false            #
+
+## Temperatureswitch :
+# automatically toggle a switch at a specified temperature. Different ones of these may be defined to monitor different temperatures and switch different swithxes
+# useful to turn on a fan or water pump to cool the hotend
+#temperatureswitch.hotend.enable              true             #
+#temperatureswitch.hotend.designator          T                # first character of the temperature control designator to use as the temperature sensor to monitor
+#temperatureswitch.hotend.switch              misc             # select which switch to use, matches the name of the defined switch
+#temperatureswitch.hotend.threshold_temp      60.0             # temperature to turn on (if rising) or off the switch
+#temperatureswitch.hotend.heatup_poll         15               # poll heatup at 15 sec intervals
+#temperatureswitch.hotend.cooldown_poll       60               # poll cooldown at 60 sec intervals
+
+
+## Endstops
+endstops_enable                              true             # the endstop module is enabled by default and can be disabled here
+#corexy_homing                               false            # set to true if homing on a hbot or corexy
+alpha_min_endstop                            5.3!^            # add a ! to invert if endstop is NO connected to ground
+alpha_max_endstop                            1.8^             # NOTE set to nc if this is not installed
+alpha_homing_direction                       home_to_min      # or set to home_to_max and set alpha_max
+alpha_min                                    0                # this gets loaded after homing when home_to_min is set
+alpha_max                                    200              # this gets loaded after homing when home_to_max is set
+beta_min_endstop                             9.6!^            #
+beta_max_endstop                             9.5^             #
+beta_homing_direction                        home_to_min      #
+beta_min                                     0                #
+beta_max                                     200              #
+gamma_min_endstop                            2.13!^           #
+gamma_max_endstop                            2.12^            #
+gamma_homing_direction                       home_to_min      #
+gamma_min                                    0                #
+gamma_max                                    200              #
+
+# optional order in which axis will home, default is they all home at the same time,
+# if this is set it will force each axis to home one at a time in the specified order
+#homing_order                                 XYZ              # x axis followed by y then z last
+#move_to_origin_after_home                    false            # move XY to 0,0 after homing
+
+# optional enable limit switches, actions will stop if any enabled limit switch is triggered
+#alpha_limit_enable                          false            # set to true to enable X min and max limit switches
+#beta_limit_enable                           false            # set to true to enable Y min and max limit switches
+#gamma_limit_enable                          false            # set to true to enable Z min and max limit switches
+
+alpha_fast_homing_rate_mm_s                  50               # feedrates in mm/second
+beta_fast_homing_rate_mm_s                   50               # "
+gamma_fast_homing_rate_mm_s                  4                # "
+alpha_slow_homing_rate_mm_s                  25               # "
+beta_slow_homing_rate_mm_s                   25               # "
+gamma_slow_homing_rate_mm_s                  2                # "
+
+alpha_homing_retract_mm                      5                # distance in mm
+beta_homing_retract_mm                       5                # "
+gamma_homing_retract_mm                      1                # "
+
+#endstop_debounce_count                       100              # uncomment if you get noise on your endstops, default is 100
+
+## Z-probe
+zprobe.enable                                false           # set to true to enable a zprobe
+zprobe.probe_pin                             1.28!^          # pin probe is attached to if NC remove the !
+zprobe.slow_feedrate                         5               # mm/sec probe feed rate
+#zprobe.debounce_count                       100             # set if noisy
+zprobe.fast_feedrate                         100             # move feedrate mm/sec
+zprobe.probe_height                          5               # how much above bed to start probe
+#gamma_min_endstop                           nc              # normally 1.28. Change to nc to prevent conflict,
+
+# associated with zprobe the leveling strategy to use
+#leveling-strategy.three-point-leveling.enable         true        # a leveling strategy that probes three points to define a plane and keeps the Z parallel to that plane
+#leveling-strategy.three-point-leveling.point1         100.0,0.0   # the first probe point (x,y) optional may be defined with M557
+#leveling-strategy.three-point-leveling.point2         200.0,200.0 # the second probe point (x,y)
+#leveling-strategy.three-point-leveling.point3         0.0,200.0   # the third probe point (x,y)
+#leveling-strategy.three-point-leveling.home_first     true        # home the XY axis before probing
+#leveling-strategy.three-point-leveling.tolerance      0.03        # the probe tolerance in mm, anything less that this will be ignored, default is 0.03mm
+#leveling-strategy.three-point-leveling.probe_offsets  0,0,0       # the probe offsets from nozzle, must be x,y,z, default is no offset
+#leveling-strategy.three-point-leveling.save_plane     false       # set to true to allow the bed plane to be saved with M500 default is false
+
+## Panel
+panel.enable                                 false             # set to true to enable the panel code
+
+# Example for reprap discount GLCD
+# on glcd EXP1 is to left and EXP2 is to right, pin 1 is bottom left, pin 2 is top left etc.
+# +5v is EXP1 pin 10, Gnd is EXP1 pin 9
+#panel.lcd                                   reprap_discount_glcd     #
+#panel.spi_channel                           0                 # spi channel to use  ; GLCD EXP1 Pins 3,5 (MOSI, SCLK)
+#panel.spi_cs_pin                            0.16              # spi chip select     ; GLCD EXP1 Pin 4
+#panel.encoder_a_pin                         3.25!^            # encoder pin         ; GLCD EXP2 Pin 3
+#panel.encoder_b_pin                         3.26!^            # encoder pin         ; GLCD EXP2 Pin 5
+#panel.click_button_pin                      1.30!^            # click button        ; GLCD EXP1 Pin 2
+#panel.buzz_pin                              1.31              # pin for buzzer      ; GLCD EXP1 Pin 1
+#panel.back_button_pin                       2.11!^            # back button         ; GLCD EXP2 Pin 8
+
+# pins used with other panels
+#panel.up_button_pin                         0.1!              # up button if used
+#panel.down_button_pin                       0.0!              # down button if used
+#panel.click_button_pin                      0.18!             # click button if used
+
+panel.menu_offset                            0                 # some panels will need 1 here
+
+panel.alpha_jog_feedrate                     6000              # x jogging feedrate in mm/min
+panel.beta_jog_feedrate                      6000              # y jogging feedrate in mm/min
+panel.gamma_jog_feedrate                     200               # z jogging feedrate in mm/min
+
+panel.hotend_temperature                     185               # temp to set hotend when preheat is selected
+panel.bed_temperature                        60                # temp to set bed when preheat is selected
+
+## Custom menus : Example of a custom menu entry, which will show up in the Custom entry.
+# NOTE _ gets converted to space in the menu and commands, | is used to separate multiple commands
+custom_menu.power_on.enable                false              #
+custom_menu.power_on.name                  Power_on          #
+custom_menu.power_on.command               M80               #
+
+custom_menu.power_off.enable               false              #
+custom_menu.power_off.name                 Power_off         #
+custom_menu.power_off.command              M81               #
+
+
+## Network settings
+network.enable                               false            # enable the ethernet network services
+network.webserver.enable                     true             # enable the webserver
+network.telnet.enable                        true             # enable the telnet server
+network.ip_address                           auto             # use dhcp to get ip address
+# uncomment the 3 below to manually setup ip address
+#network.ip_address                           192.168.3.222    # the IP address
+#network.ip_mask                              255.255.255.0    # the ip mask
+#network.ip_gateway                           192.168.3.1      # the gateway address
+#network.mac_override                         xx.xx.xx.xx.xx.xx  # override the mac address, only do this if you have a conflict

--- a/src/config.default
+++ b/src/config.default
@@ -180,12 +180,12 @@ gamma_max                                    200              #
 #beta_limit_enable                           false            # set to true to enable Y min and max limit switches
 #gamma_limit_enable                          false            # set to true to enable Z min and max limit switches
 
-alpha_fast_homing_rate_mm_s                  50               # feedrates in mm/second
-beta_fast_homing_rate_mm_s                   50               # "
-gamma_fast_homing_rate_mm_s                  4                # "
-alpha_slow_homing_rate_mm_s                  25               # "
-beta_slow_homing_rate_mm_s                   25               # "
-gamma_slow_homing_rate_mm_s                  2                # "
+alpha_fast_homing_rate_mm_s                  500               # feedrates in mm/second
+beta_fast_homing_rate_mm_s                   500               # "
+gamma_fast_homing_rate_mm_s                  40                # "
+alpha_slow_homing_rate_mm_s                  250               # "
+beta_slow_homing_rate_mm_s                   250               # "
+gamma_slow_homing_rate_mm_s                  20                # "
 
 alpha_homing_retract_mm                      5                # distance in mm
 beta_homing_retract_mm                       5                # "

--- a/src/config.default
+++ b/src/config.default
@@ -1,18 +1,7 @@
-# NOTE Lines must not exceed 132 characters
-## Robot module configurations : general handling of movement G-codes and slicing into moves
-default_feed_rate                            4000             # Default rate ( mm/minute ) for G1/G2/G3 moves
-default_seek_rate                            4000             # Default rate ( mm/minute ) for G0 moves
-mm_per_arc_segment                           0.0              # Fixed length for line segments that divide arcs 0 to disable
-mm_max_arc_error                             0.01             # The maximum error for line segments that divide arcs 0 to disable
-                                                              # note it is invalid for both the above be 0
-                                                              # if both are used, will use largest segment length based on radius
-#mm_per_line_segment                          5                # Lines can be cut into segments ( not usefull with cartesian
-                                                              # coordinates robots ).
-
 # Arm solution configuration : Cartesian robot. Translates mm positions into stepper positions
 alpha_steps_per_mm                           80               # Steps per mm for alpha stepper
 beta_steps_per_mm                            80               # Steps per mm for beta stepper
-gamma_steps_per_mm                           1600             # Steps per mm for gamma stepper
+gamma_steps_per_mm                           80             # Steps per mm for gamma stepper
 
 # Planner module configuration : Look-ahead and acceleration configuration
 planner_queue_size                           32               # DO NOT CHANGE THIS UNLESS YOU KNOW EXACTLY WHAT YOU ARE DOING
@@ -28,13 +17,13 @@ junction_deviation                           0.05             # Similar to the o
 #minimum_planner_speed                       0.0              # sets the minimum planner speed in mm/sec
 
 # Stepper module configuration
-microseconds_per_step_pulse                  2                # Duration of step pulses to stepper drivers, in microseconds
-base_stepping_frequency                      1000           # Base frequency for stepping
+microseconds_per_step_pulse                  5                # Duration of step pulses to stepper drivers, in microseconds
+base_stepping_frequency                      100000           # Base frequency for stepping
 
 # Cartesian axis speed limits
 x_axis_max_speed                             30000            # mm/min
 y_axis_max_speed                             30000            # mm/min
-z_axis_max_speed                             300              # mm/min
+z_axis_max_speed                             30000            # mm/min
 
 # Stepper module pins ( ports, and pin numbers, appending "!" to the number will invert a pin )
 alpha_step_pin                               3.2              # Pin for alpha stepper step signal
@@ -53,7 +42,7 @@ gamma_step_pin                               5.7              # Pin for gamma st
 gamma_dir_pin                                5.5              # Pin for gamma stepper direction
 gamma_en_pin                                 7.6              # Pin for gamma enable
 gamma_current                                1.5              # Z stepper motor current
-gamma_max_rate                               300.0            # mm/min
+gamma_max_rate                               30000.0          # mm/min
 
 ## System configuration
 # Serial communications configuration ( baud rate defaults to 9600 if undefined )
@@ -85,50 +74,22 @@ extruder.hotend.step_pin                        6.4              # Pin for extru
 extruder.hotend.dir_pin                         6.5              # Pin for extruder dir signal
 extruder.hotend.en_pin                          1.7              # Pin for extruder enable signal
 
-# extruder offset
-#extruder.hotend.x_offset                        0                # x offset from origin in mm
-#extruder.hotend.y_offset                        0                # y offset from origin in mm
-#extruder.hotend.z_offset                        0                # z offset from origin in mm
-
-# firmware retract settings when using G10/G11, these are the defaults if not defined, must be defined for each extruder if not using the defaults
-#extruder.hotend.retract_length                  3               # retract length in mm
-#extruder.hotend.retract_feedrate                45              # retract feedrate in mm/sec
-#extruder.hotend.retract_recover_length          0               # additional length for recover
-#extruder.hotend.retract_recover_feedrate        8               # recover feedrate in mm/sec (should be less than retract feedrate)
-#extruder.hotend.retract_zlift_length            0               # zlift on retract in mm, 0 disables
-#extruder.hotend.retract_zlift_feedrate          6000            # zlift feedrate in mm/min (Note mm/min NOT mm/sec)
-
-delta_current                                1.5              # First extruder stepper motor current
 
 # Second extruder module configuration
-#extruder.hotend2.enable                          true             # Whether to activate the extruder module at all. All configuration is ignored if false
-#extruder.hotend2.steps_per_mm                    140              # Steps per mm for extruder stepper
-#extruder.hotend2.default_feed_rate               600              # Default rate ( mm/minute ) for moves where only the extruder moves
-#extruder.hotend2.acceleration                    500              # Acceleration for the stepper motor, as of 0.6, arbitrary ratio
-#extruder.hotend2.max_speed                       50               # mm/s
+extruder.hotend2.enable                          false            # Whether to activate the extruder module at all. All configuration is ignored if false
+extruder.hotend2.steps_per_mm                    140              # Steps per mm for extruder stepper
+extruder.hotend2.default_feed_rate               600              # Default rate ( mm/minute ) for moves where only the extruder moves
+extruder.hotend2.acceleration                    500              # Acceleration for the stepper motor, as of 0.6, arbitrary ratio
+extruder.hotend2.max_speed                       50               # mm/s
 
-#extruder.hotend2.step_pin                        6.10             # Pin for extruder step signal
-#extruder.hotend2.dir_pin                         2.9              # Pin for extruder dir signal
-#extruder.hotend2.en_pin                          2.8              # Pin for extruder enable signal
-
-#extruder.hotend2.x_offset                        0                # x offset from origin in mm
-#extruder.hotend2.y_offset                        25.0             # y offset from origin in mm
-#extruder.hotend2.z_offset                        0                # z offset from origin in mm
-#epsilon_current                              1.5              # Second extruder stepper motor current
+extruder.hotend2.step_pin                        6.10             # Pin for extruder step signal
+extruder.hotend2.dir_pin                         2.9              # Pin for extruder dir signal
+extruder.hotend2.en_pin                          2.8              # Pin for extruder enable signal
 
 
 ## Laser module configuration
 laser_module_enable                          false            # Whether to activate the laser module at all. All configuration is
                                                               # ignored if false.
-#laser_module_pin                             2.5             # this pin will be PWMed to control the laser. Only P2.0 - P2.5, P1.18, P1.20, P1.21, P1.23, P1.24, P1.26, P3.25, P3.26
-                                                              # can be used since laser requires hardware PWM
-#laser_module_maximum_power                   1.0             # this is the maximum duty cycle that will be applied to the laser
-#laser_module_minimum_power                   0.0             # This is a value just below the minimum duty cycle that keeps the laser
-                                                              # active without actually burning.
-#laser_module_default_power                   0.8             # This is the default laser power that will be used for cuts if a power has not been specified.  The value is a scale between
-                                                              # the maximum and minimum power levels specified above
-#laser_module_pwm_period                      20              # this sets the pwm frequency as the period in microseconds
-
 ## Temperature control configuration
 # First hotend configuration
 temperature_control.hotend.enable            true             # Whether to activate this ( "hotend" ) module at all.
@@ -150,7 +111,7 @@ temperature_control.hotend.designator        T                #
 #temperature_control.hotend.max_pwm          64               # max pwm, 64 is a good value if driving a 12v resistor with 24v.
 
 # Second hotend configuration
-temperature_control.hotend2.enable            true             # Whether to activate this ( "hotend" ) module at all.
+temperature_control.hotend2.enable            false           # Whether to activate this ( "hotend" ) module at all.
                                                               # All configuration is ignored if false.
 
 temperature_control.hotend2.thermistor_pin    adc.7             # Pin for the thermistor to read
@@ -187,27 +148,13 @@ switch.fan.input_on_command                  M106             #
 switch.fan.input_off_command                 M107             #
 switch.fan.output_pin                        4.1              #
 switch.fan.output_type                       pwm              # pwm output settable with S parameter in the input_on_comand
-#switch.fan.max_pwm                           255              # set max pwm for the pin default is 255
+switch.fan.max_pwm                           255              # set max pwm for the pin default is 255
 
-#switch.misc.enable                           true             #
-#switch.misc.input_on_command                 M42              #
-#switch.misc.input_off_command                M43              #
-#switch.misc.output_pin                       2.4              #
-#switch.misc.output_type                      digital          # just an on or off pin
-
-# Switch module for spindle control
-#switch.spindle.enable                        false            #
-
-## Temperatureswitch :
-# automatically toggle a switch at a specified temperature. Different ones of these may be defined to monitor different temperatures and switch different swithxes
-# useful to turn on a fan or water pump to cool the hotend
-#temperatureswitch.hotend.enable              true             #
-#temperatureswitch.hotend.designator          T                # first character of the temperature control designator to use as the temperature sensor to monitor
-#temperatureswitch.hotend.switch              misc             # select which switch to use, matches the name of the defined switch
-#temperatureswitch.hotend.threshold_temp      60.0             # temperature to turn on (if rising) or off the switch
-#temperatureswitch.hotend.heatup_poll         15               # poll heatup at 15 sec intervals
-#temperatureswitch.hotend.cooldown_poll       60               # poll cooldown at 60 sec intervals
-
+switch.misc.enable                           true             #
+switch.misc.input_on_command                 M42              #
+switch.misc.input_off_command                M43              #
+switch.misc.output_pin                       7.7              #
+switch.misc.output_type                      pwm          # just an on or off pin
 
 ## Endstops
 endstops_enable                              true             # the endstop module is enabled by default and can be disabled here
@@ -228,11 +175,6 @@ gamma_homing_direction                       home_to_min      #
 gamma_min                                    0                #
 gamma_max                                    200              #
 
-# optional order in which axis will home, default is they all home at the same time,
-# if this is set it will force each axis to home one at a time in the specified order
-#homing_order                                 XYZ              # x axis followed by y then z last
-#move_to_origin_after_home                    false            # move XY to 0,0 after homing
-
 # optional enable limit switches, actions will stop if any enabled limit switch is triggered
 #alpha_limit_enable                          false            # set to true to enable X min and max limit switches
 #beta_limit_enable                           false            # set to true to enable Y min and max limit switches
@@ -251,72 +193,3 @@ gamma_homing_retract_mm                      1                # "
 
 #endstop_debounce_count                       100              # uncomment if you get noise on your endstops, default is 100
 
-## Z-probe
-zprobe.enable                                false           # set to true to enable a zprobe
-zprobe.probe_pin                             1.28!^          # pin probe is attached to if NC remove the !
-zprobe.slow_feedrate                         5               # mm/sec probe feed rate
-#zprobe.debounce_count                       100             # set if noisy
-zprobe.fast_feedrate                         100             # move feedrate mm/sec
-zprobe.probe_height                          5               # how much above bed to start probe
-#gamma_min_endstop                           nc              # normally 1.28. Change to nc to prevent conflict,
-
-# associated with zprobe the leveling strategy to use
-#leveling-strategy.three-point-leveling.enable         true        # a leveling strategy that probes three points to define a plane and keeps the Z parallel to that plane
-#leveling-strategy.three-point-leveling.point1         100.0,0.0   # the first probe point (x,y) optional may be defined with M557
-#leveling-strategy.three-point-leveling.point2         200.0,200.0 # the second probe point (x,y)
-#leveling-strategy.three-point-leveling.point3         0.0,200.0   # the third probe point (x,y)
-#leveling-strategy.three-point-leveling.home_first     true        # home the XY axis before probing
-#leveling-strategy.three-point-leveling.tolerance      0.03        # the probe tolerance in mm, anything less that this will be ignored, default is 0.03mm
-#leveling-strategy.three-point-leveling.probe_offsets  0,0,0       # the probe offsets from nozzle, must be x,y,z, default is no offset
-#leveling-strategy.three-point-leveling.save_plane     false       # set to true to allow the bed plane to be saved with M500 default is false
-
-## Panel
-panel.enable                                 false             # set to true to enable the panel code
-
-# Example for reprap discount GLCD
-# on glcd EXP1 is to left and EXP2 is to right, pin 1 is bottom left, pin 2 is top left etc.
-# +5v is EXP1 pin 10, Gnd is EXP1 pin 9
-#panel.lcd                                   reprap_discount_glcd     #
-#panel.spi_channel                           0                 # spi channel to use  ; GLCD EXP1 Pins 3,5 (MOSI, SCLK)
-#panel.spi_cs_pin                            0.16              # spi chip select     ; GLCD EXP1 Pin 4
-#panel.encoder_a_pin                         3.25!^            # encoder pin         ; GLCD EXP2 Pin 3
-#panel.encoder_b_pin                         3.26!^            # encoder pin         ; GLCD EXP2 Pin 5
-#panel.click_button_pin                      1.30!^            # click button        ; GLCD EXP1 Pin 2
-#panel.buzz_pin                              1.31              # pin for buzzer      ; GLCD EXP1 Pin 1
-#panel.back_button_pin                       2.11!^            # back button         ; GLCD EXP2 Pin 8
-
-# pins used with other panels
-#panel.up_button_pin                         0.1!              # up button if used
-#panel.down_button_pin                       0.0!              # down button if used
-#panel.click_button_pin                      0.18!             # click button if used
-
-panel.menu_offset                            0                 # some panels will need 1 here
-
-panel.alpha_jog_feedrate                     6000              # x jogging feedrate in mm/min
-panel.beta_jog_feedrate                      6000              # y jogging feedrate in mm/min
-panel.gamma_jog_feedrate                     200               # z jogging feedrate in mm/min
-
-panel.hotend_temperature                     185               # temp to set hotend when preheat is selected
-panel.bed_temperature                        60                # temp to set bed when preheat is selected
-
-## Custom menus : Example of a custom menu entry, which will show up in the Custom entry.
-# NOTE _ gets converted to space in the menu and commands, | is used to separate multiple commands
-custom_menu.power_on.enable                false              #
-custom_menu.power_on.name                  Power_on          #
-custom_menu.power_on.command               M80               #
-
-custom_menu.power_off.enable               false              #
-custom_menu.power_off.name                 Power_off         #
-custom_menu.power_off.command              M81               #
-
-
-## Network settings
-network.enable                               false            # enable the ethernet network services
-network.webserver.enable                     true             # enable the webserver
-network.telnet.enable                        true             # enable the telnet server
-network.ip_address                           auto             # use dhcp to get ip address
-# uncomment the 3 below to manually setup ip address
-#network.ip_address                           192.168.3.222    # the IP address
-#network.ip_mask                              255.255.255.0    # the ip mask
-#network.ip_gateway                           192.168.3.1      # the gateway address
-#network.mac_override                         xx.xx.xx.xx.xx.xx  # override the mac address, only do this if you have a conflict

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -87,6 +87,12 @@ Kernel::Kernel(){
     this->grbl_mode= this->config->value( grbl_mode_checksum )->by_default(false)->as_bool();
     this->ok_per_line= this->config->value( ok_per_line_checksum )->by_default(true)->as_bool();
 
+    // Configure the step ticker
+    this->base_stepping_frequency = this->config->value(base_stepping_frequency_checksum)->by_default(100000)->as_number();
+    float microseconds_per_step_pulse = this->config->value(microseconds_per_step_pulse_checksum)->by_default(5)->as_number();
+    this->acceleration_ticks_per_second = THEKERNEL->config->value(acceleration_ticks_per_second_checksum)->by_default(1000)->as_number();
+
+
     this->step_ticker = new StepTicker();
 
     // Core modules

--- a/src/libs/StepTicker.cpp
+++ b/src/libs/StepTicker.cpp
@@ -157,7 +157,7 @@ void StepTicker::add_motor_to_active_list(StepperMotor* motor)
     bool enabled= active_motor.any(); // see if interrupt was previously enabled
     active_motor[motor->index]= 1;
     if(!enabled) {
-        this->step_timer->attach_us( this, &StepTicker::step_tick, this->period_us); 
+        this->step_timer->attach_us( this, &StepTicker::step_tick, this->period_us);
     }
 }
 

--- a/src/libs/StepTicker.cpp
+++ b/src/libs/StepTicker.cpp
@@ -40,7 +40,7 @@ StepTicker::StepTicker(){
     this->a_move_finished = false;
     this->do_move_finished = 0;
     this->unstep.reset();
-    this->set_frequency(100000);
+    this->set_frequency(10000);
     this->set_reset_delay(5);
     this->set_acceleration_ticks_per_second(1000);
     this->num_motors= 0;

--- a/src/libs/StepTicker.h
+++ b/src/libs/StepTicker.h
@@ -49,10 +49,6 @@ class StepTicker{
         void start();
 
         friend class StepperMotor;
-    
-        LPC_TIMER_T* stepTimer;
-		LPC_TIMER_T* unstepTimer;
-		LPC_TIMER_T* accelerationTimer;
 
         // TOADDBACK was private
         volatile uint32_t tick_cnt;

--- a/src/libs/StepTicker.h
+++ b/src/libs/StepTicker.h
@@ -66,13 +66,6 @@ class StepTicker{
         uint8_t num_motors;
         volatile bool a_move_finished;
 
-        //Ticker* step_timer;
-        //Ticker* acceleration_timer;
-        //Timeout* unstep_timer;
-
-
-
-
 };
 
 

--- a/src/libs/StepTicker.h
+++ b/src/libs/StepTicker.h
@@ -50,11 +50,16 @@ class StepTicker{
 
         friend class StepperMotor;
     
+        LPC_TIMER_T* stepTimer;
+		LPC_TIMER_T* unstepTimer;
+		LPC_TIMER_T* accelerationTimer;
+
         // TOADDBACK was private
         volatile uint32_t tick_cnt;
         uint32_t period_us;
         uint32_t reset_delay_us;
     private:
+
         float frequency;
         uint32_t acceleration_period_us;
         std::vector<std::function<void(void)>> acceleration_tick_handlers;
@@ -65,9 +70,11 @@ class StepTicker{
         uint8_t num_motors;
         volatile bool a_move_finished;
 
-        Ticker* step_timer;
-        Ticker* acceleration_timer;
-        Timeout* unstep_timer;
+        //Ticker* step_timer;
+        //Ticker* acceleration_timer;
+        //Timeout* unstep_timer;
+
+
 
 
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,54 +17,6 @@ DigitalOut leds[4] = {
 		DigitalOut(LED4)
 };
 
-DigitalOut st = DigitalOut(P3_2);
-
-LPC_TIMER_T* testTimer;
-int t_cnt = 0;
-bool l_state = false;
-
-/*
-extern "C" void TIMER1_IRQHandler (void)
-{
-/*
-    //LPC_TIM1->IR |= 1 << 0;
-    //StepTicker::getInstance()->unstep_tick();
-	//StepTicker::global_step_ticker->unstep_tick();
-	/*
-	if(l_state){
-		st = 0;
-		l_state = false;
-	} else {
-		st = 1;
-		l_state = true;
-	}
-	*/
-/*
-	t_cnt++;
-	testTimer->IR = 1;
-	__DSB();
-	//testTimer->TCR = 0x2;  // reset
-	//testTimer->TCR = 1; // enable = 1, reset = 0
-	st= (t_cnt++ & 0x1000) ? 1 : 0;
-*/
-
-/*
-	testTimer->CTCR = 0x0; // timer mode
-	uint32_t PCLK = SystemCoreClock;
-	testTimer->TCR = 0x2;  // reset
-
-	uint32_t prescale = PCLK / 10000000;
-	testTimer->PR = prescale - 1;
-	testTimer->TCR = 1; // enable = 1, reset = 0
-
-	testTimer->MR[0] = 10;
-	testTimer->MCR |= 1;
-	NVIC_EnableIRQ(TIMER0_IRQn);
-*/
-/*
-}
-*/
-
 int main() {
 
 	int cnt = 0;
@@ -72,7 +24,7 @@ int main() {
 	// Kernel creates modules, and receives and dispatches events between them
 	Kernel* kernel = new Kernel();
 
-	// Say hello ( TODO : Add back version and all )
+	// Say hello ( TODO : Add back version and all )
 	kernel->streams->printf("Smoothie2 dev\n");
 
 	// Create and add main modules
@@ -91,36 +43,15 @@ int main() {
 
 	// Clear the configuration cache as it is no longer needed
 	kernel->config->config_cache_clear();
-/*
-	testTimer = ((LPC_TIMER_T *)LPC_TIMER1_BASE);
-
-	testTimer->CTCR = 0x0; // timer mode
-	uint32_t PCLK = SystemCoreClock;
-	testTimer->TCR = 0x2;  // reset
-
-	uint32_t prescale = PCLK / 1000000; // default to 1MHz (1 us ticks)
-	//testTimer->PR = prescale - 1;
-	testTimer->PR = 158;
-	testTimer->TCR = 0; // enable = 1, reset = 0
-
-	testTimer->MR[0] = 1;
-	testTimer->MCR |= 1;
-	//NVIC_SetPriority(TIMER1_IRQn,1);
-	//NVIC_EnableIRQ(TIMER1_IRQn);
-	NVIC_EnableIRQ(TIMER0_IRQn);
-*/
 
 	// Main loop
 	while(1){
-
-
 		if(THEKERNEL->is_using_leds()) {
 			// flash led 2 to show we are alive
 			leds[0]= (cnt++ & 0x1000) ? 1 : 0;
 		}
 		THEKERNEL->call_event(ON_MAIN_LOOP);
 		THEKERNEL->call_event(ON_IDLE);
-
 	}
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ int main() {
 	// Kernel creates modules, and receives and dispatches events between them
 	Kernel* kernel = new Kernel();
 
-	// Say hello ( TODO : Add back version and all )
+	// Say hello ( TODO: Add back version and all )
 	kernel->streams->printf("Smoothie2 dev\n");
 
 	// Create and add main modules

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,54 @@ DigitalOut leds[4] = {
 		DigitalOut(LED4)
 };
 
+DigitalOut st = DigitalOut(P3_2);
+
+LPC_TIMER_T* testTimer;
+int t_cnt = 0;
+bool l_state = false;
+
+/*
+extern "C" void TIMER1_IRQHandler (void)
+{
+/*
+    //LPC_TIM1->IR |= 1 << 0;
+    //StepTicker::getInstance()->unstep_tick();
+	//StepTicker::global_step_ticker->unstep_tick();
+	/*
+	if(l_state){
+		st = 0;
+		l_state = false;
+	} else {
+		st = 1;
+		l_state = true;
+	}
+	*/
+/*
+	t_cnt++;
+	testTimer->IR = 1;
+	__DSB();
+	//testTimer->TCR = 0x2;  // reset
+	//testTimer->TCR = 1; // enable = 1, reset = 0
+	st= (t_cnt++ & 0x1000) ? 1 : 0;
+*/
+
+/*
+	testTimer->CTCR = 0x0; // timer mode
+	uint32_t PCLK = SystemCoreClock;
+	testTimer->TCR = 0x2;  // reset
+
+	uint32_t prescale = PCLK / 10000000;
+	testTimer->PR = prescale - 1;
+	testTimer->TCR = 1; // enable = 1, reset = 0
+
+	testTimer->MR[0] = 10;
+	testTimer->MCR |= 1;
+	NVIC_EnableIRQ(TIMER0_IRQn);
+*/
+/*
+}
+*/
+
 int main() {
 
 	int cnt = 0;
@@ -43,15 +91,36 @@ int main() {
 
 	// Clear the configuration cache as it is no longer needed
 	kernel->config->config_cache_clear();
+/*
+	testTimer = ((LPC_TIMER_T *)LPC_TIMER1_BASE);
+
+	testTimer->CTCR = 0x0; // timer mode
+	uint32_t PCLK = SystemCoreClock;
+	testTimer->TCR = 0x2;  // reset
+
+	uint32_t prescale = PCLK / 1000000; // default to 1MHz (1 us ticks)
+	//testTimer->PR = prescale - 1;
+	testTimer->PR = 158;
+	testTimer->TCR = 0; // enable = 1, reset = 0
+
+	testTimer->MR[0] = 1;
+	testTimer->MCR |= 1;
+	//NVIC_SetPriority(TIMER1_IRQn,1);
+	//NVIC_EnableIRQ(TIMER1_IRQn);
+	NVIC_EnableIRQ(TIMER0_IRQn);
+*/
 
 	// Main loop
 	while(1){
+
+
 		if(THEKERNEL->is_using_leds()) {
 			// flash led 2 to show we are alive
 			leds[0]= (cnt++ & 0x1000) ? 1 : 0;
 		}
 		THEKERNEL->call_event(ON_MAIN_LOOP);
 		THEKERNEL->call_event(ON_IDLE);
+
 	}
 
 }

--- a/src/makefile
+++ b/src/makefile
@@ -13,7 +13,7 @@ MRI_BREAK_ON_INIT ?= 1
 # Can set OPTIMIZATION to 0 to disable compiler optimizations. This makes debugging easier but the code will run more
 # slowly. It may run so slowly that it fails to execute properly since some routines (ie. step tickers) are
 # time sensitive.
-OPTIMIZATION        :=  0
+#OPTIMIZATION        :=  0
 
 
 

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -213,7 +213,7 @@ void Robot::load_config()
         actuators[a] = new StepperMotor(pins[0], pins[1], pins[2]);
 
         actuators[a]->change_steps_per_mm(THEKERNEL->config->value(checksums[a][3])->by_default(a == 2 ? 2560.0F : 80.0F)->as_number());
-        actuators[a]->set_max_rate(THEKERNEL->config->value(checksums[a][4])->by_default(30000.0F)->as_number());
+        actuators[a]->set_max_rate(THEKERNEL->config->value(checksums[a][4])->by_default(30000.0F)->as_number()/60.0F);
     }
 
     check_max_actuator_speeds(); // check the configs are sane


### PR DESCRIPTION
This pull request focus on updating the step generation method to using chip timers instead of the mbed timers. This resolves some problems reported with step generation, namely in Bambino boards.

Recommendation for future work: Update step generation with variable acceleation, like in recent smoothie v1 firmware.
